### PR TITLE
increase delays to hopefully decrease non-fast-forward errors

### DIFF
--- a/lib/worker/batcher.ex
+++ b/lib/worker/batcher.ex
@@ -819,7 +819,7 @@ defmodule BorsNG.Worker.Batcher do
   # and GitHub allowing a Status-bearing commit to be pushed to master.
   # As a workaround, retry with exponential backoff.
   # This should retry *nine times*, by the way.
-  defp push_with_retry(repo_conn, commit, into_branch, timeout \\ 1) do
+  defp push_with_retry(repo_conn, commit, into_branch, timeout \\ 10) do
     Process.sleep(timeout)
 
     result =
@@ -831,7 +831,7 @@ defmodule BorsNG.Worker.Batcher do
 
     case result do
       {:ok, _} -> result
-      _ when timeout >= 512 -> result
+      _ when timeout >= 5120 -> result
       _ -> push_with_retry(repo_conn, commit, into_branch, timeout * 2)
     end
   end


### PR DESCRIPTION
Recently the frequency of messages like: `This PR was included in a batch that successfully built, but then failed to merge into #{target_branch} (it was a non-fast-forward update). It will be automatically retried.` has been increasing. I suspect this is also due to us querying GitHub too quickly. Since there's already a retry function used in the code that leads to this error, we increase the delay by a factor of 10 (from a max of 512 ms up to 5120 ms).