### PR TITLE
compute scrollHeight outside loop that adds elements

### DIFF
--- a/assets/js/expand-row.js
+++ b/assets/js/expand-row.js
@@ -81,6 +81,7 @@ function doExpandRow(td) {
     const headItems = Array.prototype.slice.call(headRow.children);
     const colSpan = row.children.length;
     const items = Array.prototype.slice.call(row.children);
+    const itemsScrollHeight = items.map(item => item.scrollHeight);
     const l = items.length;
     const borsExp = document.createElement("tr");
     borsExp.className = "exp";
@@ -91,7 +92,7 @@ function doExpandRow(td) {
     borsExpInternal.appendChild(borsExpDl);
     let foundOne = false;
     for (var i = 0; i !== l; ++i) {
-        if (items[i].scrollHeight === 0) {
+        if (itemsScrollHeight[i] === 0) {
             foundOne = true;
             const dt = document.createElement("dt");
             dt.appendChild(document.createTextNode(headItems[i].innerText));


### PR DESCRIPTION
This was causing lag in the browser, especially since we have 1900+ PRs.

cf. https://web.dev/articles/avoid-large-complex-layouts-and-layout-thrashing#avoid_layout_thrashing