### PR TITLE
fix: better processing of Co-authored-by lines in squash commits

### DIFF
--- a/lib/worker/batcher.ex
+++ b/lib/worker/batcher.ex
@@ -535,12 +535,12 @@ defmodule BorsNG.Worker.Batcher do
                 Logger.debug("User #{inspect(user)}")
 
                 # If a user doesn't have a public email address in their GH profile
-                # then get the email from the first commit to the PR
+                # then use their ID based email
                 user_email =
                   if user.email != nil do
                     user.email
                   else
-                    Enum.at(commits, 0).author_email
+                    "#{user.id}+#{user.login}@users.noreply.github.com"
                   end
 
                 # The head sha is the final commit in the PR.

--- a/test/batcher/message_test.exs
+++ b/test/batcher/message_test.exs
@@ -314,4 +314,68 @@ defmodule BorsNG.Worker.BatcherMessageTest do
 
     assert expected_message == actual_message
   end
+
+  test "commit message from squash commits contains both co-authored lines from PR body and commits" do
+    expected_message = """
+    Synchronize background and foreground processing (#1)
+
+    Fixes that annoying bug.
+
+    Co-authored-by: C <c@c>
+    Co-authored-by: D <d@d>
+    Co-authored-by: B <b@b>
+    """
+
+    title = "Synchronize background and foreground processing"
+
+    # also test that extra whitespace which confuses GitHub gets stripped
+    body = """
+    Fixes that annoying bug.
+
+    Co-authored-by: C <c@c>
+
+    Co-authored-by: D <d@d>
+
+
+
+    <!-- boilerplate follows -->
+
+    Thank you for contributing to my awesome OSS project!
+    To make sure your PR is accepted ASAP, make sure all of this
+    stuff is done:
+
+    - [ ] Run the linter
+    - [ ] Run any new or changed tests
+    - [ ] This PR fixes #___ (fill in if it exists)
+    - [ ] Make sure your commit messages make sense
+    """
+
+    user_email = "a@a"
+
+    pr = %{
+      number: 1,
+      title: title,
+      body: body
+    }
+
+    commits = [
+      %{author_email: user_email, author_name: "A"},
+      %{author_email: "b@b", author_name: "B"},
+      %{author_email: user_email, author_name: "A"},
+      %{author_email: "b@b", author_name: "B"},
+      %{author_email: user_email, author_name: "A"}
+    ]
+
+    actual_message =
+      Message.generate_squash_commit_message(
+        pr,
+        commits,
+        user_email,
+        "\n\n<!-- boilerplate follows -->"
+      )
+
+    assert expected_message == actual_message
+  end
+
+
 end


### PR DESCRIPTION
We change the generation of the commit message for squash commits so that "Co-authored-by" lines included in the PR body are collected and placed directly before the "Co-authored-by" lines created by bors for the other commits in the PR. This should ensure that there is no unnecessary whitespace that confuses GitHub.

cf. https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/co-authored-by.20bors.20issue

I also fixed some buggy code trying to find user emails which was causing bors to commit PRs with the wrong email address.