### PR TITLE
feat: Zulip notification on failed batch

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -28,6 +28,13 @@ config :bors,
   log_outgoing: {:system, "BORS_LOG_OUTGOING", false},
   poll_period: {:system, :integer, "BORS_POLL_PERIOD", 1_800_000}
 
+config :bors,
+  zulip_api_url: {:system, "ZULIP_API_URL", ""},
+  zulip_bot_email: {:system, "ZULIP_BOT_EMAIL", ""},
+  zulip_bot_api_key: {:system, "ZULIP_BOT_API_KEY", ""},
+  zulip_channel_name: {:system, "ZULIP_CHANNEL_NAME", ""},
+  zulip_topic: {:system, "ZULIP_TOPIC", ""}
+
 # General application configuration
 config :bors, BorsNG,
   command_trigger: {:system, :string, "COMMAND_TRIGGER", "bors"},

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -57,10 +57,3 @@ config :bors, :oauth2, BorsNG.GitHub.OAuth2Mock
 config :bors, BorsNG.GitHub.OAuth2,
   client_id: "III",
   client_secret: "YYY"
-
-config :bors, BorsNG.Worker.Batcher.Registry,
-  zulip_api_url: "",
-  zulip_bot_email: "",
-  zulip_bot_api_key: "",
-  zulip_channel_name: "",
-  zulip_topic: ""

--- a/config/prod.secret.exs
+++ b/config/prod.secret.exs
@@ -36,13 +36,6 @@ config :bors, BorsNG.Endpoint,
   ssl: {:system, :boolean, "FORCE_SSL", true},
   force_ssl: [rewrite_on: [:x_forwarded_proto]]
 
-config :bors, BorsNG.Worker.Batcher.Registry,
-  zulip_api_url: {:system, "ZULIP_API_URL", ""},
-  zulip_bot_email: {:system, "ZULIP_BOT_EMAIL", ""},
-  zulip_bot_api_key: {:system, "ZULIP_BOT_API_KEY", ""},
-  zulip_channel_name: {:system, "ZULIP_CHANNEL_NAME", ""},
-  zulip_topic: {:system, "ZULIP_TOPIC", ""}
-
 config :bors, BorsNG.WebhookParserPlug, webhook_secret: {:system, "GITHUB_WEBHOOK_SECRET"}
 
 config :bors, BorsNG.GitHub.OAuth2,

--- a/config/test.exs
+++ b/config/test.exs
@@ -26,10 +26,3 @@ config :bors, :oauth2, BorsNG.GitHub.OAuth2Mock
 config :bors, :is_test, true
 
 config :bors, :celebrate_new_year, false
-
-config :bors, BorsNG.Worker.Batcher.Registry,
-  zulip_api_url: "",
-  zulip_bot_email: "",
-  zulip_bot_api_key: "",
-  zulip_channel_name: "",
-  zulip_topic: ""

--- a/lib/worker/batcher.ex
+++ b/lib/worker/batcher.ex
@@ -25,6 +25,7 @@ defmodule BorsNG.Worker.Batcher do
   use GenServer
   alias BorsNG.Worker.Batcher
   alias BorsNG.Worker.Batcher.Divider
+  alias BorsNG.Worker.Zulip
   alias BorsNG.Database.Repo
   alias BorsNG.Database.Batch
   alias BorsNG.Database.BatchState
@@ -845,6 +846,10 @@ defmodule BorsNG.Worker.Batcher do
 
     patches = Enum.map(patch_links, & &1.patch)
     state = Divider.split_batch(patch_links, batch)
+
+    fail_message = ""
+
+    Zulip.send_message("⚠️ bors batch failed\n\n" <> fail_message)
 
     # The batch failed, so it's OK to push the next batch on top of the same commit we saw
     # see do_get_base/4

--- a/lib/worker/zulip.ex
+++ b/lib/worker/zulip.ex
@@ -43,7 +43,7 @@ defmodule BorsNG.Worker.Zulip do
         end
       rescue
         e ->
-          Logger.error("Failed to send Zulip notification: #{inspect(e)}")
+          Logger.error("Failed to send Zulip message: #{message}\n\nerror: #{inspect(e)}")
           :error
       end
     end

--- a/lib/worker/zulip.ex
+++ b/lib/worker/zulip.ex
@@ -12,36 +12,40 @@ defmodule BorsNG.Worker.Zulip do
   require Logger
 
   def send_message(message) do
-    try do
-      zulip_api_url = Confex.fetch_env!(:bors, :zulip_api_url)
-      bot_email = Confex.fetch_env!(:bors, :zulip_bot_email)
-      bot_api_key = Confex.fetch_env!(:bors, :zulip_bot_api_key)
-      channel_name = Confex.fetch_env!(:bors, :zulip_channel_name)
-      topic = Confex.fetch_env!(:bors, :zulip_topic)
+    if Application.get_env(:bors, :is_test) do
+      :ok
+    else
+      try do
+        zulip_api_url = Confex.fetch_env!(:bors, :zulip_api_url)
+        bot_email = Confex.fetch_env!(:bors, :zulip_bot_email)
+        bot_api_key = Confex.fetch_env!(:bors, :zulip_bot_api_key)
+        channel_name = Confex.fetch_env!(:bors, :zulip_channel_name)
+        topic = Confex.fetch_env!(:bors, :zulip_topic)
 
-      # Skip if any required config is empty
-      if empty_string?(zulip_api_url) or empty_string?(bot_email) or empty_string?(bot_api_key) or empty_string?(channel_name) or empty_string?(topic) do
-        Logger.info("Missing Zulip config. Zulip notification was not sent.")
-        :ok
-      else
-        body = %{
-          "type" => "channel",
-          "to" => channel_name,
-          "topic" => topic,
-          "content" => message
-        }
+        # Skip if any required config is empty
+        if empty_string?(zulip_api_url) or empty_string?(bot_email) or empty_string?(bot_api_key) or empty_string?(channel_name) or empty_string?(topic) do
+          Logger.info("Missing Zulip config. Zulip notification was not sent.")
+          :ok
+        else
+          body = %{
+            "type" => "channel",
+            "to" => channel_name,
+            "topic" => topic,
+            "content" => message
+          }
 
-        client = Tesla.client([
-          {Tesla.Middleware.BasicAuth, username: bot_email, password: bot_api_key},
-          Tesla.Middleware.FormUrlencoded
-        ], Tesla.Adapter.Hackney)
+          client = Tesla.client([
+            {Tesla.Middleware.BasicAuth, username: bot_email, password: bot_api_key},
+            Tesla.Middleware.FormUrlencoded
+          ], Tesla.Adapter.Hackney)
 
-        Tesla.post(client, zulip_api_url <> "messages", body)
+          Tesla.post(client, zulip_api_url <> "messages", body)
+        end
+      rescue
+        e ->
+          Logger.error("Failed to send Zulip notification: #{inspect(e)}")
+          :error
       end
-    rescue
-      e ->
-        Logger.error("Failed to send Zulip notification: #{inspect(e)}")
-        :error
     end
   end
 

--- a/test/batcher/batcher_test.exs
+++ b/test/batcher/batcher_test.exs
@@ -21,6 +21,7 @@ defmodule BorsNG.Worker.BatcherTest do
 
     proj =
       %Project{
+        name: "project_name",
         installation_id: inst.id,
         repo_xref: 14,
         staging_branch: "staging"


### PR DESCRIPTION
The idea is to find all the places in the Batcher code where the `state` of a `Batch` is modified, and then run a new `send_zulip/2` function. (I just searched for uses of `Batch.changeset` and narrowed down to the ones which mentioned `state`.)

This also fixes the Zulip config after #23. 

(I really should add some better testing for the Zulip functionality. At the moment at least the `build_message` functions are being tested, but `BorsNG.Worker.Zulip.send_message` is skipped in testing.)