### PR TITLE
fix: try harder to skip commits by PR author when generating Co-authored-by lines

### DIFF
--- a/lib/worker/batcher.ex
+++ b/lib/worker/batcher.ex
@@ -550,6 +550,8 @@ defmodule BorsNG.Worker.Batcher do
                     "#{user.id}+#{user.login}@users.noreply.github.com"
                   end
 
+                user_name = user.name || user.login
+
                 # The head sha is the final commit in the PR.
                 source_sha = pr.head_sha
                 Logger.info("Staging branch #{stmp}")
@@ -581,6 +583,7 @@ defmodule BorsNG.Worker.Batcher do
                     pr,
                     commits,
                     user_email,
+                    user_name,
                     toml.cut_body_after
                   )
 
@@ -596,7 +599,7 @@ defmodule BorsNG.Worker.Batcher do
                           tree: merge_commit.tree,
                           parents: [prev_head],
                           commit_message: commit_message,
-                          committer: %{name: user.name || user.login, email: user_email}
+                          committer: %{name: user_name, email: user_email}
                         }
                       )
                   end

--- a/lib/worker/batcher/message.ex
+++ b/lib/worker/batcher/message.ex
@@ -189,16 +189,20 @@ defmodule BorsNG.Worker.Batcher.Message do
     end
   end
 
-  def generate_squash_commit_message(pr, commits, user_email, cut_body_after) do
+  def generate_squash_commit_message(pr, commits, user_email, user_name, cut_body_after) do
     message_body = cut_body(pr.body, cut_body_after)
 
     commit_co_authors =
       commits
-      |> Enum.filter(&(&1.author_email != user_email))
+      |> Enum.filter(&(&1.author_email != user_email && &1.author_name != user_name))
       |> Enum.map(&"Co-authored-by: #{&1.author_name} <#{&1.author_email}>")
       |> Enum.join("\n")
+    # possible TODO: get Co-authored-by lines from each commit message?
+    # cf. https://github.com/bors-ng/bors-ng/issues/987
 
     # filter out Co-authored-by lines from message_body and attach to co_authors
+    # possible TODO: transform @login to username <email>
+    # cf. https://github.com/bors-ng/bors-ng/issues/1041
     {body_co_authors, message_body} = filter_lines(message_body, ~r/^Co-authored-by: /)
     # join body_co_authors to commit_co_authors and then remove all empty lines
     co_authors = body_co_authors <> "\n" <> commit_co_authors

--- a/test/batcher/message_test.exs
+++ b/test/batcher/message_test.exs
@@ -290,6 +290,7 @@ defmodule BorsNG.Worker.BatcherMessageTest do
     """
 
     user_email = "a@a"
+    user_name = "A"
 
     pr = %{
       number: 1,
@@ -309,6 +310,7 @@ defmodule BorsNG.Worker.BatcherMessageTest do
         pr,
         commits,
         user_email,
+        user_name,
         "\n\n<!-- boilerplate follows -->"
       )
 
@@ -353,6 +355,7 @@ defmodule BorsNG.Worker.BatcherMessageTest do
     """
 
     user_email = "a@a"
+    user_name = "A"
 
     pr = %{
       number: 1,
@@ -374,6 +377,73 @@ defmodule BorsNG.Worker.BatcherMessageTest do
         pr,
         commits,
         user_email,
+        user_name,
+        "\n\n<!-- boilerplate follows -->"
+      )
+
+    assert expected_message == actual_message
+  end
+
+  test "commit message from squash commits does not include co-authored-by lines for commits by PR author" do
+    expected_message = """
+    Synchronize background and foreground processing (#1)
+
+    Fixes that annoying bug.
+
+    Co-authored-by: C <c@c>
+    Co-authored-by: E <e@e>
+    Co-authored-by: D <d@d>
+    """
+
+    title = "Synchronize background and foreground processing"
+
+    # also test that extra whitespace which confuses GitHub gets stripped
+    body = """
+    Fixes that annoying bug.
+
+    Co-authored-by: C <c@c>
+    Co-authored-by: E <e@e>
+
+    Co-authored-by: D <d@d>
+    Co-authored-by: C <c@c>
+
+
+    <!-- boilerplate follows -->
+
+    Thank you for contributing to my awesome OSS project!
+    To make sure your PR is accepted ASAP, make sure all of this
+    stuff is done:
+
+    - [ ] Run the linter
+    - [ ] Run any new or changed tests
+    - [ ] This PR fixes #___ (fill in if it exists)
+    - [ ] Make sure your commit messages make sense
+    """
+
+    user_email = "a@a"
+    user_name = "A"
+
+    pr = %{
+      number: 1,
+      title: title,
+      body: body
+    }
+
+    commits = [
+      %{author_email: user_email, author_name: "A"},
+      %{author_email: "ab@ab", author_name: "A"},
+      %{author_email: user_email, author_name: "A"},
+      %{author_email: "a@a", author_name: "A A"},
+      %{author_email: "e@e", author_name: "E"},
+      %{author_email: user_email, author_name: "A"}
+    ]
+
+    actual_message =
+      Message.generate_squash_commit_message(
+        pr,
+        commits,
+        user_email,
+        user_name,
         "\n\n<!-- boilerplate follows -->"
       )
 


### PR DESCRIPTION
Instead of just filtering out commits which have the same email, we also filter out commits which have the same name.