### PR TITLE
feat(delegation): add a one-week expiry warning

### DIFF
--- a/lib/database/context/delegation.ex
+++ b/lib/database/context/delegation.ex
@@ -5,12 +5,12 @@ defmodule BorsNG.Database.Context.Delegation do
   Two kinds of work live here:
 
     * `sweep/0` — the time-driven pass. It deletes delegations that have
-      passed their `expires_at` (posting an "expired" notice), posts a
-      24-hour warning for delegations about to expire, and backfills
-      `default_expiry_sec` onto any lingering forever-delegations. There is
-      no GitHub event for "a delegation just expired" or "expires in 24h", so
-      this has to be polled; `BorsNG.Worker.DelegationTimer` runs it on an
-      interval.
+      passed their `expires_at` (posting an "expired" notice), posts warnings
+      as a delegation approaches expiry (a week out, then a day out), and
+      backfills `default_expiry_sec` onto any lingering forever-delegations.
+      There is no GitHub event for "a delegation just expired" or "expires
+      soon", so this has to be polled; `BorsNG.Worker.DelegationTimer` runs it
+      on an interval.
 
     * `reconcile_default_expiry/2` — the config-driven part. When bors reads a
       `bors.toml` that sets `default_expiry_sec`, any forever-delegations on
@@ -34,13 +34,27 @@ defmodule BorsNG.Database.Context.Delegation do
 
   require Logger
 
+  # Warning tiers, ordered from earliest to latest. Each fires once when a
+  # delegation enters its window, recording the time in its own column so it
+  # isn't repeated. The windows are disjoint — each is bounded below by the
+  # next tier's threshold — so a single sweep posts at most one warning per
+  # delegation, while a long-lived delegation still gets each warning in turn
+  # (a week out, then a day out).
+  @day_sec 24 * 60 * 60
+  @week_sec 7 * @day_sec
+  @warning_tiers [
+    {:week_warning_sent_at, @day_sec, @week_sec, "a week"},
+    {:warning_sent_at, 0, @day_sec, "24 hours"}
+  ]
+
   @doc """
   Run the time-driven delegation pass: expire past-due delegations, warn about
-  delegations expiring within 24 hours, and backfill `default_expiry_sec` onto
-  forever-delegations whose PR hasn't been touched since the default was set.
+  delegations approaching expiry (a week out, then a day out), and backfill
+  `default_expiry_sec` onto forever-delegations whose PR hasn't been touched
+  since the default was set.
 
   Backfill runs last so that a short default doesn't produce both a backfill
-  comment and a 24-hour warning in the same tick; the warning, if any, lands on
+  comment and an expiry warning in the same tick; the warning, if any, lands on
   the following sweep.
   """
   def sweep do
@@ -133,14 +147,19 @@ defmodule BorsNG.Database.Context.Delegation do
   end
 
   defp warn_delegations do
+    Enum.each(@warning_tiers, &warn_tier/1)
+  end
+
+  defp warn_tier({column, lower_sec, upper_sec, label}) do
     now = NaiveDateTime.utc_now() |> NaiveDateTime.truncate(:second)
-    warn_until = NaiveDateTime.add(now, 24 * 60 * 60, :second)
+    lower = NaiveDateTime.add(now, lower_sec, :second)
+    upper = NaiveDateTime.add(now, upper_sec, :second)
 
     candidates =
       Repo.all(
         from(d in UserPatchDelegation,
-          where: not is_nil(d.expires_at) and is_nil(d.warning_sent_at),
-          where: d.expires_at > ^now and d.expires_at <= ^warn_until,
+          where: not is_nil(d.expires_at) and is_nil(field(d, ^column)),
+          where: d.expires_at > ^lower and d.expires_at <= ^upper,
           preload: [:user, patch: :project]
         )
       )
@@ -151,9 +170,9 @@ defmodule BorsNG.Database.Context.Delegation do
     |> Enum.each(fn {d, idx} ->
       pace_comment(idx)
 
-      if post_warning_comment(d) do
+      if post_warning_comment(d, label) do
         d
-        |> Ecto.Changeset.change(warning_sent_at: now)
+        |> Ecto.Changeset.change(%{column => now})
         |> Repo.update!()
       end
     end)
@@ -221,15 +240,15 @@ defmodule BorsNG.Database.Context.Delegation do
     safe_post_comment(d.patch.project, d.patch.pr_xref, msg)
   end
 
-  defp post_warning_comment(d) do
+  defp post_warning_comment(d, label) do
     now = NaiveDateTime.utc_now()
     secs_remaining = NaiveDateTime.diff(d.expires_at, now)
     duration_str = Command.format_duration(secs_remaining)
 
     msg =
       ":hourglass_flowing_sand: @#{d.user.login}, your delegation on this PR expires " <>
-        "in approximately #{duration_str} " <>
-        "(at #{Command.format_expires_at(d.expires_at)})."
+        "in less than #{label} " <>
+        "(approximately #{duration_str}, at #{Command.format_expires_at(d.expires_at)})."
 
     safe_post_comment(d.patch.project, d.patch.pr_xref, msg)
   end

--- a/lib/database/user_patch_delegation.ex
+++ b/lib/database/user_patch_delegation.ex
@@ -12,6 +12,7 @@ defmodule BorsNG.Database.UserPatchDelegation do
     field(:expires_at, :naive_datetime)
     field(:delegated_at_commit, :string)
     field(:warning_sent_at, :naive_datetime)
+    field(:week_warning_sent_at, :naive_datetime)
     timestamps()
   end
 
@@ -25,7 +26,8 @@ defmodule BorsNG.Database.UserPatchDelegation do
       :patch_id,
       :expires_at,
       :delegated_at_commit,
-      :warning_sent_at
+      :warning_sent_at,
+      :week_warning_sent_at
     ])
     |> validate_required([:user_id, :patch_id])
     |> unique_constraint(

--- a/lib/worker/delegation_timer.ex
+++ b/lib/worker/delegation_timer.ex
@@ -2,12 +2,12 @@ defmodule BorsNG.Worker.DelegationTimer do
   @moduledoc """
   Periodically runs the time-driven delegation pass
   (`BorsNG.Database.Context.Delegation.sweep/0`): expiring past-due
-  delegations, warning about ones expiring within 24 hours, and backfilling a
-  `default_expiry_sec` onto forever-delegations whose PR hasn't been touched
-  since the default was configured.
+  delegations, warning about ones approaching expiry (a week out, then a day
+  out), and backfilling a `default_expiry_sec` onto forever-delegations whose
+  PR hasn't been touched since the default was configured.
 
   These actions are keyed to the passage of time — there is no GitHub event
-  that fires "this delegation expired", "expires in 24h", or "this PR's
+  that fires "this delegation expired", "expires soon", or "this PR's
   bors.toml gained a default expiry" — so something has to poll. Like the rest
   of bors's workers, this assumes a single instance (see
   `BorsNG.Worker.Batcher.Registry`); running multiple nodes would double up the

--- a/priv/repo/migrations/20260602120000_add_delegation_week_warning.exs
+++ b/priv/repo/migrations/20260602120000_add_delegation_week_warning.exs
@@ -1,0 +1,9 @@
+defmodule BorsNG.Database.Repo.Migrations.AddDelegationWeekWarning do
+  use Ecto.Migration
+
+  def change do
+    alter table(:user_patch_delegations) do
+      add(:week_warning_sent_at, :naive_datetime)
+    end
+  end
+end

--- a/test/delegation_test.exs
+++ b/test/delegation_test.exs
@@ -158,10 +158,63 @@ defmodule BorsNG.Database.Context.DelegationTest do
       assert comments() == []
     end
 
-    test "leaves future-expiring delegations alone", %{user: user, patch: patch} do
+    test "sends a week warning when expiry is within a week but beyond a day", %{
+      user: user,
+      patch: patch
+    } do
+      soon =
+        NaiveDateTime.utc_now()
+        |> NaiveDateTime.add(3 * 86_400, :second)
+        |> NaiveDateTime.truncate(:second)
+
+      d =
+        Repo.insert!(%UserPatchDelegation{
+          user_id: user.id,
+          patch_id: patch.id,
+          expires_at: soon
+        })
+
+      Delegation.sweep()
+
+      reloaded = Repo.get!(UserPatchDelegation, d.id)
+      refute is_nil(reloaded.week_warning_sent_at)
+      # The 24h warning still hasn't fired — that lands on a later sweep.
+      assert is_nil(reloaded.warning_sent_at)
+
+      assert Enum.any?(comments(), &String.contains?(&1, "expires"))
+      assert Enum.any?(comments(), &String.contains?(&1, "@alice"))
+    end
+
+    test "does not send the 24h warning when the week warning already fired", %{
+      user: user,
+      patch: patch
+    } do
+      soon =
+        NaiveDateTime.utc_now()
+        |> NaiveDateTime.add(3 * 86_400, :second)
+        |> NaiveDateTime.truncate(:second)
+
+      already =
+        NaiveDateTime.utc_now()
+        |> NaiveDateTime.add(-60, :second)
+        |> NaiveDateTime.truncate(:second)
+
+      Repo.insert!(%UserPatchDelegation{
+        user_id: user.id,
+        patch_id: patch.id,
+        expires_at: soon,
+        week_warning_sent_at: already
+      })
+
+      Delegation.sweep()
+
+      assert comments() == []
+    end
+
+    test "leaves far-future delegations alone", %{user: user, patch: patch} do
       future =
         NaiveDateTime.utc_now()
-        |> NaiveDateTime.add(7 * 86_400, :second)
+        |> NaiveDateTime.add(30 * 86_400, :second)
         |> NaiveDateTime.truncate(:second)
 
       d =
@@ -175,6 +228,7 @@ defmodule BorsNG.Database.Context.DelegationTest do
 
       reloaded = Repo.get!(UserPatchDelegation, d.id)
       assert is_nil(reloaded.warning_sent_at)
+      assert is_nil(reloaded.week_warning_sent_at)
       assert reloaded.expires_at == future
     end
 


### PR DESCRIPTION
Delegations previously got a single warning 24 hours before expiry, tracked by `warning_sent_at`. Add an earlier warning a week out so reviewers have more lead time.

Each warning is now a tier with its own sent-at column and a disjoint window, so a single sweep posts at most one warning per delegation while a long-lived delegation still gets each warning in turn (a week out, then a day out). A new `week_warning_sent_at` column tracks the week-tier warning (a migration adding `week_warning_sent_at` to the `user_patch_delegations` table is included).

The warning text now states the tier bound it just crossed ("less than a week" / "less than 24 hours") alongside the approximate time remaining and the exact expiry timestamp.

Prepared with Claude Code.