### PR TITLE
feat(delegation): revoke delegations when sensitive paths change

### DIFF
--- a/DELEGATION_INVALIDATION.md
+++ b/DELEGATION_INVALIDATION.md
@@ -6,18 +6,17 @@ later grows to touch sensitive files, that trust may no longer be warranted.
 
 The `[delegation]` section in `bors.toml` lets a project bound what a delegation
 covers, revoking it automatically when new author work strays outside that
-boundary. Two complementary keys control it (`delegate_only_paths` is a
-provisional name):
+boundary. Two complementary keys control it:
 
-- **`delegate_only_paths`** (allow-list / whitelist): the delegation covers
+- **`restrict_to_paths`** (allow-list / whitelist): the delegation covers
   **only** changes within these paths; touching anything else revokes it.
   Unset means "no scope restriction" — never "nothing is delegable."
 - **`invalidate_on_paths`** (deny-list / blacklist): these paths are sensitive
-  and always revoke, **even when they fall inside** `delegate_only_paths`.
+  and always revoke, **even when they fall inside** `restrict_to_paths`.
 
 ```toml
 [delegation]
-delegate_only_paths = ["src/**", "tests/**"]
+restrict_to_paths = ["src/**", "tests/**"]
 invalidate_on_paths = ["src/crypto.rs", ".github/**"]
 ```
 
@@ -34,7 +33,7 @@ This doc is the design spec. Landed and pending pieces:
 - **Implemented:** the `synchronize`-path invalidator, the `bors try` lint of
   `invalidate_on_paths` against the base tree, the delegate-success note
   echoing the configured paths, and the `get_repo_tree` truncation guard.
-- **Pending:** the `delegate_only_paths` allow-list (today only the
+- **Pending:** the `restrict_to_paths` allow-list (today only the
   `invalidate_on_paths` deny-list exists), `get_pr_files` pagination, sourcing
   `pr_diff` from the PR-files endpoint, `get_pr_compare` truncation detection,
   the `delta`/`pr_diff` truncation policy below, the merge-time gate, and the
@@ -103,10 +102,10 @@ exceptions *out* of that scope. Precedence is **blacklist > whitelist >
 default**:
 
 > A path is **acceptable** iff
-> `(delegate_only_paths unset OR path ∈ delegate_only_paths) AND path ∉ invalidate_on_paths`.
+> `(restrict_to_paths unset OR path ∈ restrict_to_paths) AND path ∉ invalidate_on_paths`.
 
 A delegation is revoked when any path in `relevant` is unacceptable. With
-`delegate_only_paths = ["src/**"]` and `invalidate_on_paths = ["src/crypto.rs"]`:
+`restrict_to_paths = ["src/**"]` and `invalidate_on_paths = ["src/crypto.rs"]`:
 
 | Changed file | In allow-list? | In deny-list? | Verdict |
 |--------------|----------------|---------------|---------|
@@ -244,7 +243,7 @@ deliberately honest (it implies the remedy — a smaller change) and never leaks
 that the real cause is an API ceiling. The three places it surfaces:
 
 1. **Standing note at delegation** (always, when either list is set): states
-   the delegated scope (`delegate_only_paths`, if set) and the always-sensitive
+   the delegated scope (`restrict_to_paths`, if set) and the always-sensitive
    paths (`invalidate_on_paths`), and adds that bors also revokes "if a later
    push changes too many files for it to check the full list — even if it stays
    within scope."

--- a/DELEGATION_INVALIDATION.md
+++ b/DELEGATION_INVALIDATION.md
@@ -28,16 +28,10 @@ reasoning behind the user-facing messages. The implementation lives in
 
 ## Status
 
-This doc is the design spec. Landed and pending pieces:
-
-- **Implemented:** the `synchronize`-path invalidator, the `bors try` lint of
-  `invalidate_on_paths` against the base tree, the delegate-success note
-  echoing the configured paths, and the `get_repo_tree` truncation guard.
-- **Pending:** the `restrict_to_paths` allow-list (today only the
-  `invalidate_on_paths` deny-list exists), `get_pr_files` pagination, sourcing
-  `pr_diff` from the PR-files endpoint, `get_pr_compare` truncation detection,
-  the `delta`/`pr_diff` truncation policy below, the merge-time gate, and the
-  revised comment copy.
+All of the behavior described below is implemented, with one deliberate
+omission: the proactive large-PR heads-up at delegation time was dropped (see
+"User-facing messages"). Truncation is detected in the invalidator against the
+documented file caps rather than via a dedicated GitHub-client signal.
 
 ## Goal and security direction
 

--- a/DELEGATION_INVALIDATION.md
+++ b/DELEGATION_INVALIDATION.md
@@ -1,0 +1,288 @@
+# Delegation Path Invalidation
+
+When a reviewer delegates approval rights on a pull request (`bors d=...`),
+they are trusting another user to approve *that PR as it stands*. If the PR
+later grows to touch sensitive files, that trust may no longer be warranted.
+
+The `[delegation]` section in `bors.toml` lets a project bound what a delegation
+covers, revoking it automatically when new author work strays outside that
+boundary. Two complementary keys control it (`delegate_only_paths` is a
+provisional name):
+
+- **`delegate_only_paths`** (allow-list / whitelist): the delegation covers
+  **only** changes within these paths; touching anything else revokes it.
+  Unset means "no scope restriction" — never "nothing is delegable."
+- **`invalidate_on_paths`** (deny-list / blacklist): these paths are sensitive
+  and always revoke, **even when they fall inside** `delegate_only_paths`.
+
+```toml
+[delegation]
+delegate_only_paths = ["src/**", "tests/**"]
+invalidate_on_paths = ["src/crypto.rs", ".github/**"]
+```
+
+This document explains how that mechanism decides what changed, the GitHub API
+limits that complicate it, the fail-safe policy chosen at those limits, and the
+reasoning behind the user-facing messages. The implementation lives in
+`lib/worker/delegation_invalidator.ex`, with supporting GitHub calls in
+`lib/github/github/server.ex` and the merge-time gate in `lib/web/command.ex`.
+
+## Status
+
+This doc is the design spec. Landed and pending pieces:
+
+- **Implemented:** the `synchronize`-path invalidator, the `bors try` lint of
+  `invalidate_on_paths` against the base tree, the delegate-success note
+  echoing the configured paths, and the `get_repo_tree` truncation guard.
+- **Pending:** the `delegate_only_paths` allow-list (today only the
+  `invalidate_on_paths` deny-list exists), `get_pr_files` pagination, sourcing
+  `pr_diff` from the PR-files endpoint, `get_pr_compare` truncation detection,
+  the `delta`/`pr_diff` truncation policy below, the merge-time gate, and the
+  revised comment copy.
+
+## Goal and security direction
+
+The control exists to stop a sensitive change from merging under stale trust.
+Its guiding rule is therefore asymmetric:
+
+> **Prefer over-revoking to under-revoking.** A wrongly revoked delegation
+> costs a re-issue (`bors d=...` again). A wrongly *retained* delegation can
+> let a sensitive change merge unreviewed. The first is annoying; the second
+> defeats the feature.
+
+Every ambiguous case below is resolved in the over-revoke direction.
+
+## The two comparisons
+
+bors must isolate **new author work since the delegation was issued** — and
+*only* that. It does so by intersecting two GitHub compares (both use the
+three-dot `base...head` form, which is relative to the merge base):
+
+```
+delta    = files in compare(delegated_at_commit, current_head)
+pr_diff  = files in compare(base_branch,        current_head)
+relevant = delta ∩ pr_diff
+```
+
+- **`delta`** is everything that changed since the delegation commit. This is
+  the security signal — but it is too broad on its own, because clicking
+  GitHub's **"Update branch"** button merges the base branch into the PR and
+  also fires the `synchronize` webhook. Those base-merge files land in `delta`
+  even though the author did not write them.
+
+- **`pr_diff`** is the author's net contribution to the PR (three-dot, so
+  base-only content is excluded). Its sole job is to be a **noise filter**: a
+  file that entered `delta` purely via a base-merge will *not* appear in
+  `pr_diff`, so the intersection drops it.
+
+`relevant` is thus "changed since delegation **and** genuinely authored in this
+PR." A delegation is invalidated when any path in `relevant` is **unacceptable**
+under the rule in [Deciding what's acceptable](#deciding-whats-acceptable).
+
+Worked example with `invalidate_on_paths = ["Cargo.lock"]`:
+
+| Scenario | `delta` | `pr_diff` | `relevant` | Revoke? |
+|----------|---------|-----------|------------|---------|
+| Author clicks "Update branch", pulling master's `Cargo.lock` | `{Cargo.lock}` | `{src/foo.rs}` (Cargo.lock now matches master) | `{}` | No ✅ |
+| Author edits `Cargo.lock` after delegation | `{Cargo.lock}` | `{src/foo.rs, Cargo.lock}` | `{Cargo.lock}` | Yes ✅ |
+
+Because `pr_diff` is *only* a filter, losing it (e.g. to truncation) can only
+cause us to keep noise we should have dropped — it never hides a real authored
+change. That asymmetry drives the truncation policy below.
+
+### bors.toml provenance
+
+`bors.toml` is read from the PR's **base** branch, never the head. A PR cannot
+disable invalidation by editing its own copy of the config.
+
+## Deciding what's acceptable
+
+Each path in `relevant` is classified against the two configured lists. The
+allow-list scopes what the delegation covers; the deny-list carves sensitive
+exceptions *out* of that scope. Precedence is **blacklist > whitelist >
+default**:
+
+> A path is **acceptable** iff
+> `(delegate_only_paths unset OR path ∈ delegate_only_paths) AND path ∉ invalidate_on_paths`.
+
+A delegation is revoked when any path in `relevant` is unacceptable. With
+`delegate_only_paths = ["src/**"]` and `invalidate_on_paths = ["src/crypto.rs"]`:
+
+| Changed file | In allow-list? | In deny-list? | Verdict |
+|--------------|----------------|---------------|---------|
+| `src/foo.rs` | ✅ | ❌ | acceptable |
+| `src/crypto.rs` | ✅ | ✅ | **revoke** — deny-list overrides |
+| `docs/readme.md` | ❌ | — | **revoke** — outside the delegated scope |
+
+The two lists only interact *inside* the allow-list, where the deny-list is the
+tiebreaker; everywhere else they agree. A deny-list entry that already lies
+outside the allow-list is harmless but redundant (a candidate for the bors-try
+lint to flag). An empty or unset allow-list imposes no scope restriction, so a
+deny-list-only config behaves exactly as it does today.
+
+## When invalidation runs
+
+### On push — `synchronize` webhook (fail-open, self-healing)
+
+The invalidator runs fire-and-forget from the `synchronize` handler in
+`lib/web/controllers/webhook_controller.ex`, after `patch.commit` is updated to
+the new head. Each run re-derives `delta` from the *fixed* `delegated_at_commit`
+to the *current* head, so it is stateless across pushes:
+
+- **Self-healing.** A dropped or failed `synchronize` (webhook delivery
+  failure, node restart, transient API error) is recovered by the next push,
+  which re-scans the entire range from the delegation point.
+- **Fail-open.** A push cannot be blocked, so an API error here is logged and
+  skipped rather than treated as a revocation trigger. Recovery relies on a
+  later push or the merge-time gate.
+
+### On approval — merge-time gate (fail-closed backstop)
+
+The `synchronize` path can fail open at the worst moment: an unverified push
+immediately followed by `bors r+`. The merge-time gate closes this. At the
+`r+` authorization point in `lib/web/command.ex`, a **synchronous** check runs
+before the delegation permission is honored.
+
+It only ever needs to validate `patch.commit`, because the batcher refuses to
+merge anything else: at staging (`lib/worker/batcher.ex`) it fetches the live
+PR and treats `pr.head_sha != patch.commit` as a `:race`, dropping the patch
+rather than merging a moved head. So if the head advances after approval, the
+race guard blocks that batch and the new head goes through its own
+`synchronize`.
+
+Unlike the push path, the merge gate **fails closed**: if it cannot verify the
+change is clean, it denies the approval (see the policy below).
+
+## GitHub API file ceilings
+
+The two compares hit two different GitHub endpoints with two different,
+silently-enforced ceilings. These were verified empirically against
+`leanprover-community/mathlib4` (PR #31786 / its 7905-file commits).
+
+### `compare(base...head)` — 300 files, first page only
+
+- Returns **at most 300 changed files**, and only on the **first page**. There
+  is no file pagination: page 2 returns zero files, and the page-1 `Link`
+  header carries no `rel="next"` for files (it paginates *commits* only).
+- **Truncation signal:** `length(files) == 300`. We cannot retrieve files
+  301+, so hitting 300 means "there may be more we can't see."
+- Docs: [Compare two commits](https://docs.github.com/en/rest/commits/commits#compare-two-commits)
+  — *"The list of changed files is only shown on the first page of results, and
+  it includes up to 300 changed files for the entire comparison."*
+
+### `pulls/{n}/files` — 3000 files, via real pagination
+
+- Returns up to a **3000-file** hard ceiling, paginated (default 30/page, max
+  `per_page=100`). The cap is enforced **silently by returning empty `[]`
+  pages** past 3000 — and the `Link` header *lies*: for PR #31786 it advertised
+  `rel="last"` at the diff's true size (~7210 files) even though data stops at
+  3000.
+- **Pagination must stop on the first short/empty page** (`length < per_page`),
+  *not* on the absence of `rel="next"` — otherwise a 7000-file PR triggers
+  dozens of wasted requests fetching empty pages.
+- **Truncation signal:** the PR object's `changed_files` field (from
+  `GET /pulls/{n}`) exceeds what we retrieved, or we simply hit 3000.
+- Docs: [List pull requests files](https://docs.github.com/en/rest/pulls/pulls#list-pull-requests-files)
+  — *"Responses include a maximum of 3000 files."* (`per_page` "max 100" is the
+  page size, not a page count.)
+
+### Why `pr_diff` uses the PR-files endpoint
+
+`compare(into_branch, head)` is, three-dot, identical to the PR's own file list
+(`into_branch` is the PR base, `head` is `patch.commit`). Sourcing `pr_diff`
+from `pulls/{n}/files` raises its ceiling from 300 to 3000 — a real correctness
+win, since an incomplete filter causes under-revoke. `delta` has no PR-files
+equivalent (it is an arbitrary commit range) and is stuck at 300.
+
+## Truncation policy
+
+The two truncation cases are **not** equally severe, and treating them the same
+creates a bad failure mode (see "un-actionable delegations" below). They are
+handled separately:
+
+| Case | Meaning | Handling |
+|------|---------|----------|
+| **`delta` truncated** (>300 files changed *after* delegation) | Cannot enumerate the delegate's new work; an unacceptable path might be hidden in the overflow | **Fail safe.** Over-revoke on `synchronize`; deny on `r+`. |
+| **`pr_diff` truncated** (>3000 files in the whole PR) | Only the *noise filter* is incomplete; `delta` is still fully known | **Delta-only fallback.** Evaluate `delta` without the intersection. Can only over-revoke (a base-merge file may count as authored), never under-revoke. |
+| **`delta` empty** (no changes since delegation) | Nothing to check | **Short-circuit.** Do not even fetch `pr_diff`; the delegation stands. |
+
+The allow-list makes the truncated-`delta` case fall out naturally rather than
+needing a bolted-on rule. Its normal rule is already "revoke unless every
+authored path is known-acceptable"; overflow paths we cannot see are not
+known-acceptable, so they revoke by the same logic. A deny-list alone needs the
+explicit special case "if truncated, revoke even though no *visible* path
+matched," because a sensitive path could be hiding in the overflow. The
+fail-safe *direction* — uncertainty revokes — is identical for both.
+
+### Why the split, and "un-actionable delegations"
+
+Failing closed on *any* truncation would make a large PR **un-actionable from
+the moment it is delegated**: the delegate could never `bors r+`, even after
+touching nothing, purely because the PR was big when they were handed the keys.
+
+The split avoids this. The decisive test case:
+
+| >3000-file PR, **no changes** after delegation | Split policy | Block-on-any-truncation |
+|---|---|---|
+| `bors r+` | empty `delta` → nothing to check → **approves** ✅ | `pr_diff` truncated → **denied** ❌ |
+
+Under the split policy, a delegation becomes un-actionable **only if the
+delegate's own post-delegation changes exceed ~300 files** — which is within
+their control and arguably *should* demand a fresh human review. A large but
+finished PR stays fully delegatable.
+
+## User-facing messages
+
+The entire feature reduces, for users, to one rule stated without any API
+detail:
+
+> If a change is too big for bors to check the full list of changed files, it
+> assumes a protected path *might* have been touched and plays it safe.
+
+The recurring phrase **"too many files for bors to check the full list"** is
+deliberately honest (it implies the remedy — a smaller change) and never leaks
+that the real cause is an API ceiling. The three places it surfaces:
+
+1. **Standing note at delegation** (always, when either list is set): states
+   the delegated scope (`delegate_only_paths`, if set) and the always-sensitive
+   paths (`invalidate_on_paths`), and adds that bors also revokes "if a later
+   push changes too many files for it to check the full list — even if it stays
+   within scope."
+
+2. **Revoke comment on push** (the truncation branch): "the latest push changed
+   too many files for bors to check against the paths listed in
+   `[delegation] invalidate_on_paths`, so it was revoked as a precaution."
+
+3. **Approval denied at `bors r+`** (the fail-closed gate): "this pull request
+   changes too many files for bors to check against the paths listed in
+   `[delegation] invalidate_on_paths`. A reviewer needs to approve directly, or
+   re-delegate after the change is split up."
+
+In the ordinary (non-truncation) case, the revoke comment names the offending
+path and *why* it was unacceptable — either "touched `path`, which is outside
+the paths this delegation covers" (allow-list) or "touched `path`, which is
+listed in `[delegation] invalidate_on_paths`" (deny-list) — so the author knows
+whether to narrow their change or seek a fresh review.
+
+A *proactive* large-PR heads-up at delegation time was considered and dropped:
+under the split policy a large PR alone is no longer noteworthy (only a large
+*post-delegation* push is), and that cannot be predicted when the delegation is
+issued.
+
+## Known limitations
+
+- **Missed-push window.** A `synchronize` lost *and* immediately followed by a
+  merge is the gap the merge-time gate exists to close. Outside that window,
+  the next push self-heals. The residual TOCTOU between `r+` approval and
+  staging is bounded by the batcher's `:race` guard, which refuses to merge a
+  head that has moved past `patch.commit`.
+- **`pr_diff` delta-only fallback over-revokes.** For a >3000-file PR whose
+  `delta` includes base-merge content, the missing noise filter may revoke a
+  delegation that a complete filter would have spared. This is the accepted
+  safe direction.
+- **`delta` is hard-capped at 300 by GitHub** with no pagination escape. A
+  genuinely huge post-delegation push is therefore un-mergeable by a delegate
+  by design.
+
+See also [bors-ng/rfcs](https://github.com/bors-ng/rfcs) for broader design
+documentation.

--- a/DELEGATION_INVALIDATION.md
+++ b/DELEGATION_INVALIDATION.md
@@ -146,6 +146,18 @@ race guard blocks that batch and the new head goes through its own
 Unlike the push path, the merge gate **fails closed**: if it cannot verify the
 change is clean, it denies the approval (see the policy below).
 
+Because it fails closed, a *transient* GitHub error is not free here: when the
+delta compare can't complete, `classify_delegation/6` returns `:unverifiable`
+and the gate denies the `r+`, forcing the approver to re-issue it. To keep a
+brief API blip from surfacing as a spurious denial, `:get_pr_compare` is on the
+**long retry budget** in `lib/github/github.ex` (`max_retry_elapsed_ms/1`,
+default 180s) rather than the 30s budget used for calls where giving up early is
+harmless. That budget axis is about *the cost of giving up*, not literally
+reads vs. writes — see the comment on `max_retry_elapsed_ms/1` for the full
+rationale. The advisory `invalidate_on_paths` lint deliberately stays on the
+short budget: its reads (`get_repo_tree`, `get_pr_comments`) only gate a
+cosmetic warning, so a failure just skips it.
+
 ## GitHub API file ceilings
 
 The two compares hit two different GitHub endpoints with two different,

--- a/DELEGATION_INVALIDATION.md
+++ b/DELEGATION_INVALIDATION.md
@@ -276,11 +276,29 @@ issued.
 
 ## Known limitations
 
-- **Missed-push window.** A `synchronize` lost *and* immediately followed by a
-  merge is the gap the merge-time gate exists to close. Outside that window,
-  the next push self-heals. The residual TOCTOU between `r+` approval and
-  staging is bounded by the batcher's `:race` guard, which refuses to merge a
-  head that has moved past `patch.commit`.
+- **Missed-push window.** All checks compare against the stored `patch.commit`,
+  which the `synchronize` handler updates *synchronously* before spawning the
+  (fire-and-forget) push-path invalidator. Two distinct races sit behind this,
+  with different backstops — and crucially, **neither lets unverified content
+  merge; the residual cost is an availability stall, not an integrity bypass:**
+  - *Webhook delivered, async revocation not yet landed.* `patch.commit` is
+    already fresh, so the **synchronous merge-time gate** re-derives the verdict
+    from it at `r+` time regardless of whether the background invalidator has
+    finished. This is the race the gate exists to close.
+  - *Webhook never processed (dropped, or bors was down).* `patch.commit` stays
+    stale, so the gate — which trusts the stored commit and does not re-fetch —
+    cannot see the new head. The **batcher's `:race` guard** is the backstop
+    here: at staging it compares the *live* head against `patch.commit`
+    (`batcher.ex`) and refuses to merge a head that has moved, so the unverified
+    push is dropped rather than merged. A later push (or re-`r+`) then re-gates
+    against the new head and self-heals.
+
+  Because a merge requires the live head to equal the `patch.commit` the gate
+  blessed — and a push also cancels any in-flight batch (`Batcher.cancel` in the
+  `synchronize` handler) — there is no path that merges a head bors never
+  verified. The integrity guarantee in the second case rests entirely on the
+  batcher's live-head `:race` check; weakening or bypassing it would turn the
+  gate's reliance on a possibly-stale `patch.commit` into a real bypass.
 - **`pr_diff` delta-only fallback over-revokes.** For a >3000-file PR whose
   `delta` includes base-merge content, the missing noise filter may revoke a
   delegation that a complete filter would have spared. This is the accepted

--- a/lib/github/github.ex
+++ b/lib/github/github.ex
@@ -314,6 +314,11 @@ defmodule BorsNG.GitHub do
     :ok
   end
 
+  @spec get_pr_comments(tconn, number) :: {:ok, [binary]} | {:error, term}
+  def get_pr_comments(repo_conn, number) do
+    call_with_retry(:get_pr_comments, repo_conn, {number}, 500, 4_000)
+  end
+
   @spec post_commit_status(tconn, {binary, tstatus, binary, binary}) :: :ok | {:error, term}
   def post_commit_status(repo_conn, {sha, status, msg, url}) do
     call_with_retry(:post_commit_status, repo_conn, {sha, status, msg, url}, 500, 4_000)

--- a/lib/github/github.ex
+++ b/lib/github/github.ex
@@ -207,7 +207,8 @@ defmodule BorsNG.GitHub do
     call_with_retry(:get_file, repo_conn, {branch, path}, 500, 4_000)
   end
 
-  @spec get_repo_tree(tconn, binary) :: {:ok, [binary]} | {:error, term}
+  @spec get_repo_tree(tconn, binary) ::
+          {:ok, [binary]} | {:ok, {:truncated, binary}} | {:error, term}
   def get_repo_tree(repo_conn, branch) do
     call_with_retry(:get_repo_tree, repo_conn, {branch}, 500, 4_000)
   end

--- a/lib/github/github.ex
+++ b/lib/github/github.ex
@@ -39,6 +39,12 @@ defmodule BorsNG.GitHub do
     call_with_retry(:get_pr_files, repo_conn, {pr_xref}, 500, 4_000)
   end
 
+  @spec get_pr_compare(tconn, binary, binary) ::
+          {:ok, [BorsNG.GitHub.File.t()]} | {:error, term}
+  def get_pr_compare(repo_conn, base, head) do
+    call_with_retry(:get_pr_compare, repo_conn, {base, head}, 500, 4_000)
+  end
+
   @spec get_pr!(tconn, integer | bitstring) :: BorsNG.GitHub.Pr.t()
   def get_pr!(repo_conn, pr_xref) do
     {:ok, pr} = get_pr(repo_conn, pr_xref)

--- a/lib/github/github.ex
+++ b/lib/github/github.ex
@@ -207,6 +207,11 @@ defmodule BorsNG.GitHub do
     call_with_retry(:get_file, repo_conn, {branch, path}, 500, 4_000)
   end
 
+  @spec get_repo_tree(tconn, binary) :: {:ok, [binary]} | {:error, term}
+  def get_repo_tree(repo_conn, branch) do
+    call_with_retry(:get_repo_tree, repo_conn, {branch}, 500, 4_000)
+  end
+
   @spec force_push!(tconn, binary, binary) :: binary
   def force_push!(repo_conn, sha, to) do
     {:ok, sha} = call_with_retry(:force_push, repo_conn, {sha, to}, 500, 4_000)

--- a/lib/github/github.ex
+++ b/lib/github/github.ex
@@ -525,11 +525,41 @@ defmodule BorsNG.GitHub do
     System.monotonic_time(:millisecond) - started_at >= max_elapsed_ms
   end
 
+  # Total wall-clock budget for the retry loop (not per-attempt; that's
+  # :api_github_timeout). The two values are named "read"/"write" for the
+  # common case, but the real axis is *how costly it is to give up*, which
+  # comes down to two questions:
+  #
+  #   1. Is retrying safe? All reads are idempotent, so they qualify. Some
+  #      writes are too — :post_commit_status, :force_push and :delete_branch
+  #      are all last-write-wins — whereas :merge_branch, :synthesize_commit,
+  #      :create_commit and :post_comment mutate fresh state, so a retry can
+  #      duplicate work (a second comment, a stray commit). Those never get the
+  #      long budget. But idempotency is necessary, not sufficient: it lets a
+  #      write *onto* the list, it doesn't put it there. Question 2 decides that.
+  #   2. What happens if we give up? The long budget is for calls where
+  #      surrendering to a transient GitHub blip has a real cost. This is what
+  #      separates the idempotent writes from each other: :post_commit_status is
+  #      bors reporting its own status — what users and the `ci-success` gate
+  #      watch — so a dropped update leaves a batch looking stuck; worth
+  #      grinding. A failed :force_push / :delete_branch just makes the batcher
+  #      re-run or re-clean the attempt cheaply, so they stay short. :get_pr_compare
+  #      is the sharp read example: on failure classify_delegation/6 returns
+  #      :unverifiable, which the merge-time gate treats as fail-closed and
+  #      *blocks the merge*, forcing a human to re-issue `bors r+`. Grinding for
+  #      three minutes beats that, so it sits on the long budget alongside its
+  #      sibling :get_pr_files.
+  #
+  # Anything not listed (e.g. the advisory-lint reads :get_repo_tree and
+  # :get_pr_comments, whose failure just skips a cosmetic warning) falls through
+  # to the short budget — there's nothing worth tying up a worker three minutes
+  # for. Add an action here only when giving up early would itself be harmful.
   defp max_retry_elapsed_ms(action)
        when action in [
               :get_branch,
               :get_file,
               :get_pr,
+              :get_pr_compare,
               :get_pr_files,
               :get_pr_commits,
               :get_commit_status,

--- a/lib/github/github/server.ex
+++ b/lib/github/github/server.ex
@@ -453,8 +453,11 @@ defmodule BorsNG.GitHub.Server do
          decoded <- Jason.decode!(tree_raw),
          # GitHub caps recursive trees (~100k entries / 7MB). A truncated tree
          # is missing paths, so reporting it as complete would make the lint
-         # emit false "matches no files" warnings. Treat truncation as an error
-         # so callers skip rather than mislead.
+         # emit false "matches no files" warnings. Truncation is deterministic
+         # (a refetch truncates too), so return it as a terminal {:ok, ...} so
+         # call_with_retry stops immediately rather than burning the retry
+         # budget re-fetching a multi-MB tree that can never come back whole.
+         # Callers must skip on :truncated rather than treat it as complete.
          {:truncated, false} <- {:truncated, decoded["truncated"] == true} do
       paths =
         decoded
@@ -466,7 +469,7 @@ defmodule BorsNG.GitHub.Server do
     else
       {:branch, %{status: status, body: body}} -> {:error, :get_repo_tree, status, body}
       {:tree, %{status: status, body: body}} -> {:error, :get_repo_tree, status, body}
-      {:truncated, true} -> {:error, :get_repo_tree, :truncated, branch}
+      {:truncated, true} -> {:ok, {:truncated, branch}}
     end
   end
 

--- a/lib/github/github/server.ex
+++ b/lib/github/github/server.ex
@@ -446,6 +446,26 @@ defmodule BorsNG.GitHub.Server do
     do_handle_call(:get_reviews, repo_conn, {issue_xref, nil})
   end
 
+  def do_handle_call(:get_repo_tree, repo_conn, {branch}) do
+    with {:branch, %{body: branch_raw, status: 200}} <-
+           {:branch, get!(repo_conn, "branches/#{branch}")},
+         tree_sha <- Jason.decode!(branch_raw)["commit"]["commit"]["tree"]["sha"],
+         {:tree, %{body: tree_raw, status: 200}} <-
+           {:tree, get!(repo_conn, "git/trees/#{tree_sha}?recursive=1")} do
+      paths =
+        tree_raw
+        |> Jason.decode!()
+        |> Map.get("tree", [])
+        |> Enum.filter(&(&1["type"] == "blob"))
+        |> Enum.map(& &1["path"])
+
+      {:ok, paths}
+    else
+      {:branch, %{status: status, body: body}} -> {:error, :get_repo_tree, status, body}
+      {:tree, %{status: status, body: body}} -> {:error, :get_repo_tree, status, body}
+    end
+  end
+
   def do_handle_call(:get_file, repo_conn, {branch, path}) do
     resp =
       get!(

--- a/lib/github/github/server.ex
+++ b/lib/github/github/server.ex
@@ -451,10 +451,15 @@ defmodule BorsNG.GitHub.Server do
            {:branch, get!(repo_conn, "branches/#{branch}")},
          tree_sha <- Jason.decode!(branch_raw)["commit"]["commit"]["tree"]["sha"],
          {:tree, %{body: tree_raw, status: 200}} <-
-           {:tree, get!(repo_conn, "git/trees/#{tree_sha}?recursive=1")} do
+           {:tree, get!(repo_conn, "git/trees/#{tree_sha}?recursive=1")},
+         decoded <- Jason.decode!(tree_raw),
+         # GitHub caps recursive trees (~100k entries / 7MB). A truncated tree
+         # is missing paths, so reporting it as complete would make the lint
+         # emit false "matches no files" warnings. Treat truncation as an error
+         # so callers skip rather than mislead.
+         {:truncated, false} <- {:truncated, decoded["truncated"] == true} do
       paths =
-        tree_raw
-        |> Jason.decode!()
+        decoded
         |> Map.get("tree", [])
         |> Enum.filter(&(&1["type"] == "blob"))
         |> Enum.map(& &1["path"])
@@ -463,6 +468,7 @@ defmodule BorsNG.GitHub.Server do
     else
       {:branch, %{status: status, body: body}} -> {:error, :get_repo_tree, status, body}
       {:tree, %{status: status, body: body}} -> {:error, :get_repo_tree, status, body}
+      {:truncated, true} -> {:error, :get_repo_tree, :truncated, branch}
     end
   end
 
@@ -499,6 +505,22 @@ defmodule BorsNG.GitHub.Server do
 
       %{status: status, body: raw} ->
         {:error, :post_comment, status, raw}
+    end
+  end
+
+  def do_handle_call(:get_pr_comments, repo_conn, {number}) do
+    case get!(repo_conn, "issues/#{number}/comments?per_page=100") do
+      %{body: raw, status: 200} ->
+        bodies =
+          raw
+          |> Jason.decode!()
+          |> Enum.map(&Map.get(&1, "body"))
+          |> Enum.reject(&is_nil/1)
+
+        {:ok, bodies}
+
+      e ->
+        {:error, :get_pr_comments, e.status, number}
     end
   end
 

--- a/lib/github/github/server.ex
+++ b/lib/github/github/server.ex
@@ -18,6 +18,11 @@ defmodule BorsNG.GitHub.Server do
   @content_type_raw "application/vnd.github.v3.raw"
   @content_type "application/vnd.github.v3+json"
 
+  # Page size for `pulls/{n}/files`. GitHub caps this endpoint at 100 per page
+  # and 3000 files total; see DELEGATION_INVALIDATION.md, "GitHub API file
+  # ceilings".
+  @pr_files_per_page 100
+
   @type tconn :: GitHub.tconn()
   @type ttoken :: GitHub.ttoken()
   @type trepo :: GitHub.trepo()
@@ -91,19 +96,12 @@ defmodule BorsNG.GitHub.Server do
     {:reply, {:ok, list}, state}
   end
 
-  def do_handle_call(:get_pr_files, repo_conn, {pr_xref}) do
-    case get!(repo_conn, "pulls/#{pr_xref}/files") do
-      %{body: raw, status: 200} ->
-        pr =
-          raw
-          |> Jason.decode!()
-          |> Enum.map(&GitHub.File.from_json!/1)
-
-        {:ok, pr}
-
-      e ->
-        {:error, :get_pr_files, e.status, pr_xref}
-    end
+  def do_handle_call(:get_pr_files, {{:raw, token}, repo_xref}, {pr_xref}) do
+    get_pr_files_(
+      token,
+      "#{site()}/repositories/#{repo_xref}/pulls/#{pr_xref}/files?per_page=#{@pr_files_per_page}",
+      []
+    )
   end
 
   def do_handle_call(:get_pr_compare, repo_conn, {base, head}) do
@@ -787,6 +785,37 @@ defmodule BorsNG.GitHub.Server do
     case next_headers do
       [] -> prs
       [next] -> get_open_prs_!(token, next.url, prs)
+    end
+  end
+
+  # Paginate `pulls/{n}/files`. GitHub enforces the 3000-file cap by returning
+  # empty pages past it while the Link header keeps advertising more, so we stop
+  # on the first short page (fewer than per_page) rather than when rel="next"
+  # disappears — otherwise a multi-thousand-file PR fetches dozens of empty
+  # pages. See DELEGATION_INVALIDATION.md, "GitHub API file ceilings".
+  defp get_pr_files_(token, url, acc) do
+    "token #{token}"
+    |> tesla_client(@content_type)
+    |> Tesla.get(url, query: get_url_params(url))
+    |> case do
+      {:ok, %{body: raw, status: 200, headers: headers}} ->
+        files = raw |> Jason.decode!() |> Enum.map(&GitHub.File.from_json!/1)
+        acc = acc ++ files
+
+        if length(files) < @pr_files_per_page do
+          {:ok, acc}
+        else
+          case get_next_headers(headers) do
+            [] -> {:ok, acc}
+            [next] -> get_pr_files_(token, next.url, acc)
+          end
+        end
+
+      {:ok, %{status: status}} ->
+        {:error, :get_pr_files, status, url}
+
+      _ ->
+        {:error, :get_pr_files}
     end
   end
 

--- a/lib/github/github/server.ex
+++ b/lib/github/github/server.ex
@@ -106,6 +106,22 @@ defmodule BorsNG.GitHub.Server do
     end
   end
 
+  def do_handle_call(:get_pr_compare, repo_conn, {base, head}) do
+    case get!(repo_conn, "compare/#{base}...#{head}") do
+      %{body: raw, status: 200} ->
+        files =
+          raw
+          |> Jason.decode!()
+          |> Map.get("files", [])
+          |> Enum.map(&GitHub.File.from_json!/1)
+
+        {:ok, files}
+
+      e ->
+        {:error, :get_pr_compare, e.status, {base, head}}
+    end
+  end
+
   def do_handle_call(:get_pr, repo_conn, {pr_xref}) do
     case get!(repo_conn, "pulls/#{pr_xref}") do
       %{body: raw, status: 200} ->

--- a/lib/github/github/server_mock.ex
+++ b/lib/github/github/server_mock.ex
@@ -219,18 +219,26 @@ defmodule BorsNG.GitHub.ServerMock do
     {{:error, :get_pr_files, 502, pr_xref}, %{state | :get_pr_files_error => n - 1}}
   end
 
-  def do_handle_call(:get_pr_files, repo_conn, {_pr_xref}, state) do
-    with {:ok, repo} <- Map.fetch(state, repo_conn),
-         {:ok, files} <- Map.fetch(repo, :files),
-         {:ok, z_files} <- Map.fetch(files, "Z") do
-      files =
-        Enum.map(z_files, fn {k, _} ->
-          %BorsNG.GitHub.File{filename: k}
-        end)
+  def do_handle_call(:get_pr_files, repo_conn, {pr_xref}, state) do
+    case get_in(state, [repo_conn, :pr_files, pr_xref]) do
+      # Explicit per-PR file list (a plain list of filenames).
+      filenames when is_list(filenames) ->
+        {{:ok, Enum.map(filenames, &%BorsNG.GitHub.File{filename: &1})}, state}
 
-      {{:ok, files}, state}
-    else
-      _ -> {{:error, :get_pr_files}, state}
+      # Legacy CODEOWNERS shape: :files keyed by the staging commit "Z".
+      _ ->
+        with {:ok, repo} <- Map.fetch(state, repo_conn),
+             {:ok, files} <- Map.fetch(repo, :files),
+             {:ok, z_files} <- Map.fetch(files, "Z") do
+          files =
+            Enum.map(z_files, fn {k, _} ->
+              %BorsNG.GitHub.File{filename: k}
+            end)
+
+          {{:ok, files}, state}
+        else
+          _ -> {{:error, :get_pr_files}, state}
+        end
     end
   end
 

--- a/lib/github/github/server_mock.ex
+++ b/lib/github/github/server_mock.ex
@@ -655,7 +655,13 @@ defmodule BorsNG.GitHub.ServerMock do
     with {:ok, repo} <- Map.fetch(state, repo_conn),
          {:ok, files} <- Map.fetch(repo, :files),
          branch_files when is_map(branch_files) <- Map.get(files, branch) do
-      {{:ok, Map.keys(branch_files)}, state}
+      # A repo can list branches whose tree is truncated to mirror GitHub's
+      # recursive-tree cap; the real server returns this terminal tuple.
+      if branch in Map.get(repo, :truncated_trees, []) do
+        {{:ok, {:truncated, branch}}, state}
+      else
+        {{:ok, Map.keys(branch_files)}, state}
+      end
     else
       _ -> {{:error, :get_repo_tree}, state}
     end

--- a/lib/github/github/server_mock.ex
+++ b/lib/github/github/server_mock.ex
@@ -653,6 +653,16 @@ defmodule BorsNG.GitHub.ServerMock do
     end
   end
 
+  def do_handle_call(:get_pr_comments, repo_conn, {number}, state) do
+    with {:ok, repo} <- Map.fetch(state, repo_conn),
+         {:ok, comments} <- Map.fetch(repo, :comments),
+         {:ok, c} <- Map.fetch(comments, number) do
+      {{:ok, c}, state}
+    else
+      _ -> {{:ok, []}, state}
+    end
+  end
+
   def do_handle_call(:post_comment, repo_conn, params, %{post_comment_error: 0} = state) do
     do_handle_call(:post_comment, repo_conn, params, %{state | :post_comment_error => nil})
   end

--- a/lib/github/github/server_mock.ex
+++ b/lib/github/github/server_mock.ex
@@ -244,14 +244,21 @@ defmodule BorsNG.GitHub.ServerMock do
 
   def do_handle_call(:get_pr_compare, repo_conn, {base, head}, state) do
     # Tests put a :compare map on the repo keyed by `{base, head}` whose value
-    # is a list of filenames changed between those two refs.
-    with {:ok, repo} <- Map.fetch(state, repo_conn),
-         {:ok, compare} <- Map.fetch(repo, :compare),
-         {:ok, filenames} <- Map.fetch(compare, {base, head}) do
-      files = Enum.map(filenames, &%BorsNG.GitHub.File{filename: &1})
-      {{:ok, files}, state}
+    # is a list of filenames changed between those two refs. Setting
+    # :compare_error makes the call fail, to exercise the :unverifiable paths.
+    repo = Map.get(state, repo_conn, %{})
+
+    if Map.get(repo, :compare_error, false) do
+      {{:error, :get_pr_compare, 502, {base, head}}, state}
     else
-      _ -> {{:ok, []}, state}
+      case repo |> Map.get(:compare, %{}) |> Map.fetch({base, head}) do
+        {:ok, filenames} ->
+          files = Enum.map(filenames, &%BorsNG.GitHub.File{filename: &1})
+          {{:ok, files}, state}
+
+        :error ->
+          {{:ok, []}, state}
+      end
     end
   end
 

--- a/lib/github/github/server_mock.ex
+++ b/lib/github/github/server_mock.ex
@@ -234,6 +234,19 @@ defmodule BorsNG.GitHub.ServerMock do
     end
   end
 
+  def do_handle_call(:get_pr_compare, repo_conn, {base, head}, state) do
+    # Tests put a :compare map on the repo keyed by `{base, head}` whose value
+    # is a list of filenames changed between those two refs.
+    with {:ok, repo} <- Map.fetch(state, repo_conn),
+         {:ok, compare} <- Map.fetch(repo, :compare),
+         {:ok, filenames} <- Map.fetch(compare, {base, head}) do
+      files = Enum.map(filenames, &%BorsNG.GitHub.File{filename: &1})
+      {{:ok, files}, state}
+    else
+      _ -> {{:ok, []}, state}
+    end
+  end
+
   def do_handle_call(:get_pr_commits, repo_conn, {pr_xref}, state) do
     with(
       {:ok, repo} <- Map.fetch(state, repo_conn),

--- a/lib/github/github/server_mock.ex
+++ b/lib/github/github/server_mock.ex
@@ -643,6 +643,16 @@ defmodule BorsNG.GitHub.ServerMock do
     end
   end
 
+  def do_handle_call(:get_repo_tree, repo_conn, {branch}, state) do
+    with {:ok, repo} <- Map.fetch(state, repo_conn),
+         {:ok, files} <- Map.fetch(repo, :files),
+         branch_files when is_map(branch_files) <- Map.get(files, branch) do
+      {{:ok, Map.keys(branch_files)}, state}
+    else
+      _ -> {{:error, :get_repo_tree}, state}
+    end
+  end
+
   def do_handle_call(:post_comment, repo_conn, params, %{post_comment_error: 0} = state) do
     do_handle_call(:post_comment, repo_conn, params, %{state | :post_comment_error => nil})
   end

--- a/lib/web/command.ex
+++ b/lib/web/command.ex
@@ -29,6 +29,7 @@ defmodule BorsNG.Command do
   alias BorsNG.Database.Project
   alias BorsNG.Database.User
   alias BorsNG.GitHub
+  alias BorsNG.Worker.DelegationInvalidator
   alias BorsNG.Worker.Syncer
 
   import BorsNG.Router.Helpers
@@ -477,13 +478,21 @@ defmodule BorsNG.Command do
 
           :ok
         else
-          required_permission
-          |> Permission.permission?(c.commenter, c.patch)
-          |> if do
-            Enum.each(cmd_list, &run(c, &1))
-            Enum.each(cmd_list, &log(c, &1))
-          else
-            permission_denied(c)
+          cond do
+            # Merge-time gate: a reviewer-level command relying on a delegation
+            # is re-checked against the current head and fails closed. If the
+            # gate denies, it has already revoked + commented (or explained an
+            # unverifiable check), so don't also post the generic denial.
+            required_permission == :reviewer and
+                DelegationInvalidator.verify_for_merge(c.patch, c.commenter) == :deny ->
+              :ok
+
+            Permission.permission?(required_permission, c.commenter, c.patch) ->
+              Enum.each(cmd_list, &run(c, &1))
+              Enum.each(cmd_list, &log(c, &1))
+
+            true ->
+              permission_denied(c)
           end
         end
       end
@@ -611,7 +620,7 @@ defmodule BorsNG.Command do
     c = fetch_patch(c)
 
     Task.Supervisor.start_child(BorsNG.Worker.Syncer.Supervisor, fn ->
-      BorsNG.Worker.DelegationInvalidator.lint_for_patch(c.patch.id)
+      DelegationInvalidator.lint_for_patch(c.patch.id)
     end)
 
     attemptor = Attemptor.Registry.get(c.project.id)

--- a/lib/web/command.ex
+++ b/lib/web/command.ex
@@ -734,48 +734,43 @@ defmodule BorsNG.Command do
   end
 
   def delegate_to(c, delegatee, explicit_duration) do
-    case resolve_delegate_duration(c, explicit_duration) do
-      nil ->
-        c.project.repo_xref
-        |> Project.installation_connection(Repo)
-        |> GitHub.post_comment!(
-          c.pr_xref,
-          ~s{:lock: Delegation requires an explicit expiration. Pass `for=24h`, `for=7d`, or `for=2w`, or set `default_expiry_sec` under `[delegation]` in `bors.toml`.}
-        )
+    toml = fetch_bors_toml(c)
+    duration = explicit_duration || toml_default_expiry(toml)
+    conn = Project.installation_connection(c.project.repo_xref, Repo)
 
-      duration ->
-        now = NaiveDateTime.utc_now() |> NaiveDateTime.truncate(:second)
-        expires_at = NaiveDateTime.add(now, duration, :second)
+    Delegation.reconcile_default_expiry(c.patch, toml_default_expiry(toml))
 
-        Permission.delegate(delegatee, c.patch,
-          expires_at: expires_at,
-          delegated_at_commit: c.patch.commit
-        )
+    if is_integer(duration) and duration > 0 do
+      now = NaiveDateTime.utc_now() |> NaiveDateTime.truncate(:second)
+      expires_at = NaiveDateTime.add(now, duration, :second)
 
-        Project.ping!(c.project.id)
+      Permission.delegate(delegatee, c.patch,
+        expires_at: expires_at,
+        delegated_at_commit: c.patch.commit
+      )
 
-        c.project.repo_xref
-        |> Project.installation_connection(Repo)
-        |> GitHub.post_comment!(
-          c.pr_xref,
-          ~s{:v: #{delegatee.login} can now approve this pull request until #{format_expires_at(expires_at)} (in #{format_duration(duration)}). To approve and merge, reply with `bors r+`. More detailed instructions are available [here](https://bors.tech/documentation/getting-started/#reviewing-pull-requests).}
-        )
+      Project.ping!(c.project.id)
+
+      msg =
+        ~s{:v: #{delegatee.login} can now approve this pull request until #{format_expires_at(expires_at)} (in #{format_duration(duration)}). To approve and merge, reply with `bors r+`. More detailed instructions are available [here](https://bors.tech/documentation/getting-started/#reviewing-pull-requests).} <>
+          invalidate_on_paths_note(toml)
+
+      GitHub.post_comment!(conn, c.pr_xref, msg)
+    else
+      GitHub.post_comment!(
+        conn,
+        c.pr_xref,
+        ~s{:lock: Delegation requires an explicit expiration. Pass `for=24h`, `for=7d`, or `for=2w`, or have a reviewer set `default_expiry_sec` under `[delegation]` in `bors.toml`.}
+      )
     end
   end
 
-  defp resolve_delegate_duration(_c, duration) when is_integer(duration) and duration > 0,
-    do: duration
-
-  defp resolve_delegate_duration(c, nil) do
+  defp fetch_bors_toml(c) do
     conn = Project.installation_connection(c.project.repo_xref, Repo)
 
     case Batcher.GetBorsToml.get(conn, c.patch.into_branch) do
-      {:ok, toml} ->
-        Delegation.reconcile_default_expiry(c.patch, toml.delegation_default_expiry_sec)
-        toml.delegation_default_expiry_sec
-
-      {:error, _} ->
-        nil
+      {:ok, toml} -> toml
+      {:error, _} -> nil
     end
   end
 
@@ -783,6 +778,19 @@ defmodule BorsNG.Command do
   @hour 60 * @minute
   @day 24 * @hour
   @week 7 * @day
+
+  defp toml_default_expiry(nil), do: nil
+  defp toml_default_expiry(toml), do: toml.delegation_default_expiry_sec
+
+  defp invalidate_on_paths_note(nil), do: ""
+  defp invalidate_on_paths_note(%{delegation_invalidate_on_paths: []}), do: ""
+
+  defp invalidate_on_paths_note(%{delegation_invalidate_on_paths: paths}) do
+    rendered = paths |> Enum.map(&"`#{&1}`") |> Enum.join(", ")
+
+    "\n\n:warning: A new author commit touching any of these paths will revoke this delegation: " <>
+      rendered <> "."
+  end
 
   @doc """
   Render a delegation expiry timestamp for a comment, e.g.

--- a/lib/web/command.ex
+++ b/lib/web/command.ex
@@ -739,9 +739,9 @@ defmodule BorsNG.Command do
   end
 
   def delegate_to(c, delegatee, explicit_duration) do
-    toml = fetch_bors_toml(c)
-    duration = explicit_duration || toml_default_expiry(toml)
     conn = Project.installation_connection(c.project.repo_xref, Repo)
+    toml = fetch_bors_toml(conn, c)
+    duration = explicit_duration || toml_default_expiry(toml)
 
     Delegation.reconcile_default_expiry(c.patch, toml_default_expiry(toml))
 
@@ -770,9 +770,7 @@ defmodule BorsNG.Command do
     end
   end
 
-  defp fetch_bors_toml(c) do
-    conn = Project.installation_connection(c.project.repo_xref, Repo)
-
+  defp fetch_bors_toml(conn, c) do
     case Batcher.GetBorsToml.get(conn, c.patch.into_branch) do
       {:ok, toml} -> toml
       {:error, _} -> nil

--- a/lib/web/command.ex
+++ b/lib/web/command.ex
@@ -767,7 +767,7 @@ defmodule BorsNG.Command do
 
       msg =
         ~s{:v: #{delegatee.login} can now approve this pull request until #{format_expires_at(expires_at)} (in #{format_duration(duration)}). To approve and merge, reply with `bors r+`. More detailed instructions are available [here](https://bors.tech/documentation/getting-started/#reviewing-pull-requests).} <>
-          invalidate_on_paths_note(toml)
+          delegation_paths_note(toml)
 
       GitHub.post_comment!(conn, c.pr_xref, msg)
     else
@@ -794,14 +794,41 @@ defmodule BorsNG.Command do
   defp toml_default_expiry(nil), do: nil
   defp toml_default_expiry(toml), do: toml.delegation_default_expiry_sec
 
-  defp invalidate_on_paths_note(nil), do: ""
-  defp invalidate_on_paths_note(%{delegation_invalidate_on_paths: []}), do: ""
+  # Standing note appended to the delegate-success comment, describing what
+  # will revoke the delegation. See DELEGATION_INVALIDATION.md, "User-facing
+  # messages".
+  defp delegation_paths_note(nil), do: ""
 
-  defp invalidate_on_paths_note(%{delegation_invalidate_on_paths: paths}) do
+  defp delegation_paths_note(toml) do
+    sentences =
+      []
+      |> add_paths_sentence(toml.delegation_restrict_to_paths, fn rendered ->
+        "This delegation only covers changes within #{rendered}; an author commit " <>
+          "touching anything else will revoke it."
+      end)
+      |> add_paths_sentence(toml.delegation_invalidate_on_paths, fn rendered ->
+        "A new author commit touching any of these paths will revoke this delegation: " <>
+          rendered <> "."
+      end)
+
+    case sentences do
+      [] ->
+        ""
+
+      _ ->
+        caveat =
+          "Bors also revokes it if a later push changes too many files for it to check " <>
+            "the full list — even if it stays within scope."
+
+        "\n\n:warning: " <> Enum.join(sentences ++ [caveat], " ")
+    end
+  end
+
+  defp add_paths_sentence(acc, [], _fun), do: acc
+
+  defp add_paths_sentence(acc, paths, fun) do
     rendered = paths |> Enum.map(&"`#{&1}`") |> Enum.join(", ")
-
-    "\n\n:warning: A new author commit touching any of these paths will revoke this delegation: " <>
-      rendered <> "."
+    acc ++ [fun.(rendered)]
   end
 
   @doc """

--- a/lib/web/command.ex
+++ b/lib/web/command.ex
@@ -609,6 +609,11 @@ defmodule BorsNG.Command do
 
   def run(c, {:try, arguments}) do
     c = fetch_patch(c)
+
+    Task.Supervisor.start_child(BorsNG.Worker.Syncer.Supervisor, fn ->
+      BorsNG.Worker.DelegationInvalidator.lint_for_patch(c.patch.id)
+    end)
+
     attemptor = Attemptor.Registry.get(c.project.id)
     Attemptor.tried(attemptor, c.patch.id, arguments)
   end

--- a/lib/web/controllers/webhook_controller.ex
+++ b/lib/web/controllers/webhook_controller.ex
@@ -65,6 +65,7 @@ defmodule BorsNG.WebhookController do
   alias BorsNG.Worker.Attemptor
   alias BorsNG.Worker.Batcher
   alias BorsNG.Worker.BranchDeleter
+  alias BorsNG.Worker.DelegationInvalidator
   alias BorsNG.Command
   alias BorsNG.Database.Attempt
   alias BorsNG.Database.Batch
@@ -443,6 +444,11 @@ defmodule BorsNG.WebhookController do
     Attemptor.cancel(attemptor, p.id)
     commit = conn.body_params["pull_request"]["head"]["sha"]
     Repo.update!(Patch.changeset(p, %{commit: commit}))
+
+    # Fire-and-forget: revoke delegations whose author commits since delegation
+    # touch paths configured in bors.toml's [delegation] invalidate_on_paths.
+    # Runs after patch.commit is updated so it sees the new head.
+    Task.start(fn -> DelegationInvalidator.invalidate_for_patch(p.id) end)
   end
 
   def do_webhook_pr(conn, %{action: "edited", patch: patch}) do

--- a/lib/web/controllers/webhook_controller.ex
+++ b/lib/web/controllers/webhook_controller.ex
@@ -448,7 +448,9 @@ defmodule BorsNG.WebhookController do
     # Fire-and-forget: revoke delegations whose author commits since delegation
     # touch paths configured in bors.toml's [delegation] invalidate_on_paths.
     # Runs after patch.commit is updated so it sees the new head.
-    Task.start(fn -> DelegationInvalidator.invalidate_for_patch(p.id) end)
+    Task.Supervisor.start_child(BorsNG.Worker.Syncer.Supervisor, fn ->
+      DelegationInvalidator.invalidate_for_patch(p.id)
+    end)
   end
 
   def do_webhook_pr(conn, %{action: "edited", patch: patch}) do

--- a/lib/worker/batcher.ex
+++ b/lib/worker/batcher.ex
@@ -436,6 +436,16 @@ defmodule BorsNG.Worker.Batcher do
           :race ->
             :race
 
+          # Integrity invariant: never merge a head that differs from the
+          # patch.commit everything upstream was authorized against. This live
+          # head-vs-stored check is also the backstop the delegation merge-time
+          # gate relies on: that gate verifies the *stored* patch.commit and
+          # does not re-fetch, so if a `synchronize` was never processed it can
+          # bless a stale-but-safe commit while the real head has moved on. This
+          # comparison is what refuses that head. Weakening it (e.g. merging
+          # without this live get_pr! check) would turn the gate's reliance on a
+          # possibly-stale patch.commit into a real bypass. See
+          # DELEGATION_INVALIDATION.md, "Known limitations — Missed-push window".
           _ when pr.head_sha != patch.commit ->
             :race
 

--- a/lib/worker/batcher/bors_toml.ex
+++ b/lib/worker/batcher/bors_toml.ex
@@ -33,7 +33,8 @@ defmodule BorsNG.Worker.Batcher.BorsToml do
             update_base_for_deletes: false,
             max_batch_size: nil,
             delegation_default_expiry_sec: nil,
-            delegation_invalidate_on_paths: []
+            delegation_invalidate_on_paths: [],
+            delegation_restrict_to_paths: []
 
   @type tcommitter :: %{
           name: binary,
@@ -57,7 +58,8 @@ defmodule BorsNG.Worker.Batcher.BorsToml do
           update_base_for_deletes: boolean,
           max_batch_size: integer | nil,
           delegation_default_expiry_sec: pos_integer() | nil,
-          delegation_invalidate_on_paths: [binary]
+          delegation_invalidate_on_paths: [binary],
+          delegation_restrict_to_paths: [binary]
         }
 
   @type err ::
@@ -73,6 +75,7 @@ defmodule BorsNG.Worker.Batcher.BorsToml do
           | :max_batch_size
           | :delegation_default_expiry_sec
           | :delegation_invalidate_on_paths
+          | :delegation_restrict_to_paths
           | :empty_config
           | :parse_failed
 
@@ -95,10 +98,15 @@ defmodule BorsNG.Worker.Batcher.BorsToml do
             _ -> :invalid
           end
 
-        {delegation_default_expiry_sec, delegation_invalidate_on_paths} =
+        {delegation_default_expiry_sec, delegation_invalidate_on_paths,
+         delegation_restrict_to_paths} =
           case delegation_table do
-            :invalid -> {:invalid, :invalid}
-            m -> {Map.get(m, "default_expiry_sec", nil), Map.get(m, "invalidate_on_paths", [])}
+            :invalid ->
+              {:invalid, :invalid, :invalid}
+
+            m ->
+              {Map.get(m, "default_expiry_sec", nil), Map.get(m, "invalidate_on_paths", []),
+               Map.get(m, "restrict_to_paths", [])}
           end
 
         committer = Map.get(toml, "committer", nil)
@@ -149,7 +157,8 @@ defmodule BorsNG.Worker.Batcher.BorsToml do
           update_base_for_deletes: Map.get(toml, "update_base_for_deletes", false),
           max_batch_size: Map.get(toml, "max_batch_size", nil),
           delegation_default_expiry_sec: delegation_default_expiry_sec,
-          delegation_invalidate_on_paths: delegation_invalidate_on_paths
+          delegation_invalidate_on_paths: delegation_invalidate_on_paths,
+          delegation_restrict_to_paths: delegation_restrict_to_paths
         }
 
         case toml do
@@ -196,6 +205,9 @@ defmodule BorsNG.Worker.Batcher.BorsToml do
           %{delegation_invalidate_on_paths: paths} when not is_list(paths) ->
             {:error, :delegation_invalidate_on_paths}
 
+          %{delegation_restrict_to_paths: paths} when not is_list(paths) ->
+            {:error, :delegation_restrict_to_paths}
+
           toml ->
             status =
               toml.status
@@ -221,6 +233,9 @@ defmodule BorsNG.Worker.Batcher.BorsToml do
 
               not Enum.all?(toml.delegation_invalidate_on_paths, &is_binary/1) ->
                 {:error, :delegation_invalidate_on_paths}
+
+              not Enum.all?(toml.delegation_restrict_to_paths, &is_binary/1) ->
+                {:error, :delegation_restrict_to_paths}
 
               true ->
                 {:ok, %{toml | status: status, pr_status: pr_status}}

--- a/lib/worker/batcher/bors_toml.ex
+++ b/lib/worker/batcher/bors_toml.ex
@@ -32,7 +32,8 @@ defmodule BorsNG.Worker.Batcher.BorsToml do
             commit_title: "Merge ${PR_REFS}",
             update_base_for_deletes: false,
             max_batch_size: nil,
-            delegation_default_expiry_sec: nil
+            delegation_default_expiry_sec: nil,
+            delegation_invalidate_on_paths: []
 
   @type tcommitter :: %{
           name: binary,
@@ -55,7 +56,8 @@ defmodule BorsNG.Worker.Batcher.BorsToml do
           commit_title: binary,
           update_base_for_deletes: boolean,
           max_batch_size: integer | nil,
-          delegation_default_expiry_sec: pos_integer() | nil
+          delegation_default_expiry_sec: pos_integer() | nil,
+          delegation_invalidate_on_paths: [binary]
         }
 
   @type err ::
@@ -70,6 +72,7 @@ defmodule BorsNG.Worker.Batcher.BorsToml do
           | :commit_title
           | :max_batch_size
           | :delegation_default_expiry_sec
+          | :delegation_invalidate_on_paths
           | :empty_config
           | :parse_failed
 
@@ -85,11 +88,17 @@ defmodule BorsNG.Worker.Batcher.BorsToml do
       {:ok, toml} ->
         toml = to_map(toml)
 
-        delegation_default_expiry_sec =
+        delegation_table =
           case Map.get(toml, "delegation", nil) do
-            nil -> nil
-            d when is_map(d) -> Map.get(to_map(d), "default_expiry_sec", nil)
+            nil -> %{}
+            d when is_map(d) -> to_map(d)
             _ -> :invalid
+          end
+
+        {delegation_default_expiry_sec, delegation_invalidate_on_paths} =
+          case delegation_table do
+            :invalid -> {:invalid, :invalid}
+            m -> {Map.get(m, "default_expiry_sec", nil), Map.get(m, "invalidate_on_paths", [])}
           end
 
         committer = Map.get(toml, "committer", nil)
@@ -139,7 +148,8 @@ defmodule BorsNG.Worker.Batcher.BorsToml do
           commit_title: Map.get(toml, "commit_title", "Merge ${PR_REFS}"),
           update_base_for_deletes: Map.get(toml, "update_base_for_deletes", false),
           max_batch_size: Map.get(toml, "max_batch_size", nil),
-          delegation_default_expiry_sec: delegation_default_expiry_sec
+          delegation_default_expiry_sec: delegation_default_expiry_sec,
+          delegation_invalidate_on_paths: delegation_invalidate_on_paths
         }
 
         case toml do
@@ -183,6 +193,9 @@ defmodule BorsNG.Worker.Batcher.BorsToml do
                  (not is_nil(secs) and (not is_integer(secs) or secs <= 0)) ->
             {:error, :delegation_default_expiry_sec}
 
+          %{delegation_invalidate_on_paths: paths} when not is_list(paths) ->
+            {:error, :delegation_invalidate_on_paths}
+
           toml ->
             status =
               toml.status
@@ -205,6 +218,9 @@ defmodule BorsNG.Worker.Batcher.BorsToml do
                   toml.delegation_default_expiry_sec >
                     BorsNG.Command.delegation_max_duration_sec() ->
                 {:error, :delegation_default_expiry_sec}
+
+              not Enum.all?(toml.delegation_invalidate_on_paths, &is_binary/1) ->
+                {:error, :delegation_invalidate_on_paths}
 
               true ->
                 {:ok, %{toml | status: status, pr_status: pr_status}}

--- a/lib/worker/batcher/bors_toml.ex
+++ b/lib/worker/batcher/bors_toml.ex
@@ -85,6 +85,17 @@ defmodule BorsNG.Worker.Batcher.BorsToml do
     |> Map.new()
   end
 
+  # A delegation path entry must be a string that compiles as a glob.
+  # `:glob.matches/2` raises `badarg` on an uncompilable pattern, and it runs in
+  # the synchronous merge-time gate, so we reject bad patterns at config-parse
+  # time (clean "Configuration problem" comment) rather than crash at match
+  # time. `:glob.compile/1` returns {:ok, _} | {:error, _} without raising.
+  defp valid_glob?(pattern) when is_binary(pattern) do
+    match?({:ok, _}, :glob.compile(pattern))
+  end
+
+  defp valid_glob?(_pattern), do: false
+
   @spec new(binary) :: {:ok, t} | {:error, err}
   def new(str) when is_binary(str) do
     case Toml.decode(str) do
@@ -231,10 +242,10 @@ defmodule BorsNG.Worker.Batcher.BorsToml do
                     BorsNG.Command.delegation_max_duration_sec() ->
                 {:error, :delegation_default_expiry_sec}
 
-              not Enum.all?(toml.delegation_invalidate_on_paths, &is_binary/1) ->
+              not Enum.all?(toml.delegation_invalidate_on_paths, &valid_glob?/1) ->
                 {:error, :delegation_invalidate_on_paths}
 
-              not Enum.all?(toml.delegation_restrict_to_paths, &is_binary/1) ->
+              not Enum.all?(toml.delegation_restrict_to_paths, &valid_glob?/1) ->
                 {:error, :delegation_restrict_to_paths}
 
               true ->

--- a/lib/worker/batcher/get_bors_toml.ex
+++ b/lib/worker/batcher/get_bors_toml.ex
@@ -8,7 +8,9 @@ defmodule BorsNG.Worker.Batcher.GetBorsToml do
   alias BorsNG.GitHub
   alias BorsNG.Worker.Batcher.BorsToml
 
-  @type terror :: :fetch_failed | :parse_failed | :status | :timeout_sec
+  # Beyond :fetch_failed, get/2 delegates to BorsToml.new and passes through any
+  # of its validation errors, so the domain is BorsToml.err() | :fetch_failed.
+  @type terror :: BorsToml.err() | :fetch_failed
 
   @spec get(GitHub.tconn(), binary) :: {:ok, BorsToml.t()} | {:error, terror}
   def get(repo_conn, branch) do

--- a/lib/worker/batcher/message.ex
+++ b/lib/worker/batcher/message.ex
@@ -3,6 +3,8 @@ defmodule BorsNG.Worker.Batcher.Message do
   User-readable strings that go in commit messages and comments.
   """
 
+  alias BorsNG.Worker.Batcher.BorsToml
+
   def generate_status(:waiting) do
     {"Waiting in queue", :running}
   end
@@ -299,6 +301,10 @@ defmodule BorsNG.Worker.Batcher.Message do
     Regex.replace(~r/\B(@\S+)/, body, ~S/`\g{1}`/, global: true)
   end
 
+  # Must render every key BorsToml/GetBorsToml can emit. The catch-all below
+  # guarantees no crash; the message_test introspection guarantees every key in
+  # the spec domain has an explicit, friendly clause rather than the fallback.
+  @spec generate_bors_toml_error(BorsToml.err() | :fetch_failed) :: binary
   def generate_bors_toml_error(:parse_failed) do
     "bors.toml: syntax error"
   end

--- a/lib/worker/batcher/message.ex
+++ b/lib/worker/batcher/message.ex
@@ -323,8 +323,53 @@ defmodule BorsNG.Worker.Batcher.Message do
     "bors.toml: expected status to be a list"
   end
 
-  def generate_bors_toml_error(:blocked_labels) do
-    "bors.toml: expected blocked_labels to be a list"
+  # NB: the validator emits :block_labels (see BorsToml), not :blocked_labels.
+  def generate_bors_toml_error(:block_labels) do
+    "bors.toml: expected block_labels to be a list"
+  end
+
+  def generate_bors_toml_error(:pr_status) do
+    "bors.toml: expected pr_status to be a list"
+  end
+
+  def generate_bors_toml_error(:prerun_timeout_sec) do
+    "bors.toml: expected prerun_timeout_sec to be an integer"
+  end
+
+  def generate_bors_toml_error(:cut_body_after) do
+    "bors.toml: expected cut_body_after to be a string"
+  end
+
+  def generate_bors_toml_error(:commit_title) do
+    "bors.toml: expected commit_title to be a string"
+  end
+
+  def generate_bors_toml_error(:committer_details) do
+    "bors.toml: committer must specify both name and email"
+  end
+
+  def generate_bors_toml_error(:max_batch_size) do
+    "bors.toml: expected max_batch_size to be an integer"
+  end
+
+  def generate_bors_toml_error(:delegation_default_expiry_sec) do
+    "bors.toml: expected [delegation] default_expiry_sec to be a positive integer " <>
+      "of at most 90 days (in seconds)"
+  end
+
+  def generate_bors_toml_error(:delegation_invalidate_on_paths) do
+    "bors.toml: expected [delegation] invalidate_on_paths to be a list of glob patterns"
+  end
+
+  def generate_bors_toml_error(:delegation_restrict_to_paths) do
+    "bors.toml: expected [delegation] restrict_to_paths to be a list of glob patterns"
+  end
+
+  # Catch-all so a future validation key can never crash the renderer (and the
+  # batcher with it) the way the unhandled keys above silently did. Prefer an
+  # explicit clause with friendly wording over relying on this.
+  def generate_bors_toml_error(key) do
+    "bors.toml: invalid configuration (#{key})"
   end
 
   def get_is_new_year do

--- a/lib/worker/delegation_invalidator.ex
+++ b/lib/worker/delegation_invalidator.ex
@@ -1,0 +1,179 @@
+defmodule BorsNG.Worker.DelegationInvalidator do
+  @moduledoc """
+  Invalidates PR delegations when new author commits touch paths configured
+  in bors.toml's `[delegation] invalidate_on_paths = [...]` list.
+
+  ## bors.toml syntax
+
+      [delegation]
+      invalidate_on_paths = [
+        "Cargo.toml",
+        "Cargo.lock",
+        ".github/**",
+        "deps/**",
+      ]
+
+  Each entry is a glob pattern matched against repository-relative paths
+  (forward slashes, no leading `./`). Matching uses Erlang's `:glob` module,
+  which differs from gitignore in two important ways:
+
+    * `*` matches any sequence of characters **including `/`**, so
+      `.github/*` and `.github/**` are equivalent. There is no need to write
+      `**` to recurse into subdirectories.
+    * `?` matches a single character (not directory-aware).
+
+  Patterns are anchored: `Cargo.toml` matches only the top-level file, not
+  `foo/Cargo.toml`. Use `**/Cargo.toml` to match anywhere in the tree.
+
+  ## Triggering and false-positive avoidance
+
+  Runs from the `synchronize` webhook. To avoid false positives from
+  GitHub's "Update branch" button (which also fires `synchronize`), we use
+  the intersection of two compares to isolate "new author work since the
+  delegation was issued":
+
+      delta    = files in `compare(delegated_at_commit, current_head)`
+      pr_diff  = files in `compare(base_branch, current_head)`   (three-dot)
+      relevant = delta ∩ pr_diff
+
+  `pr_diff` is a three-dot compare anchored at the base branch, so it
+  represents only content the author has added in the PR (base-only content
+  is naturally excluded). The intersection drops anything in `delta` that
+  came from a base-merge.
+
+  A delegation is invalidated when any path in `relevant` matches any
+  configured glob.
+
+  ## bors.toml provenance
+
+  The `bors.toml` config is read from the PR's BASE branch, **not** from the
+  PR head. A PR therefore cannot disable invalidation by editing its own
+  copy of `bors.toml`.
+  """
+
+  import Ecto.Query
+
+  alias BorsNG.Database.Patch
+  alias BorsNG.Database.Project
+  alias BorsNG.Database.Repo
+  alias BorsNG.Database.UserPatchDelegation
+  alias BorsNG.GitHub
+  alias BorsNG.Worker.Batcher.GetBorsToml
+
+  require Logger
+
+  @doc """
+  Fire-and-forget entry point. Safe to call from `Task.start`. Loads the
+  patch fresh from the DB to avoid stale state.
+  """
+  @spec invalidate_for_patch(Patch.id()) :: :ok
+  def invalidate_for_patch(patch_id) do
+    case Repo.get(Patch, patch_id) do
+      nil ->
+        :ok
+
+      patch ->
+        try do
+          run(patch)
+        rescue
+          e ->
+            Logger.warning(
+              "DelegationInvalidator: crashed for patch #{patch_id}: #{Exception.message(e)}"
+            )
+
+            :ok
+        end
+    end
+  end
+
+  defp run(patch) do
+    delegations = candidate_delegations(patch.id)
+
+    if delegations == [] do
+      :ok
+    else
+      project = Repo.get!(Project, patch.project_id)
+      conn = Project.installation_connection(project.repo_xref, Repo)
+
+      with {:ok, toml} <- GetBorsToml.get(conn, patch.into_branch),
+           [_ | _] = patterns <- toml.delegation_invalidate_on_paths do
+        do_invalidate(conn, patch, patterns, delegations)
+      else
+        _ -> :ok
+      end
+    end
+  end
+
+  defp candidate_delegations(patch_id) do
+    from(d in UserPatchDelegation,
+      where: d.patch_id == ^patch_id and not is_nil(d.delegated_at_commit),
+      preload: [:user]
+    )
+    |> Repo.all()
+  end
+
+  defp do_invalidate(conn, patch, patterns, delegations) do
+    case GitHub.get_pr_compare(conn, patch.into_branch, patch.commit) do
+      {:ok, pr_diff_files} ->
+        pr_diff_set = MapSet.new(pr_diff_files, & &1.filename)
+
+        Enum.each(delegations, fn d ->
+          check_delegation(conn, patch, patterns, pr_diff_set, d)
+        end)
+
+      {:error, reason} ->
+        Logger.warning(
+          "DelegationInvalidator: compare(base, head) failed for patch #{patch.id}: #{inspect(reason)}"
+        )
+
+        :ok
+    end
+  end
+
+  defp check_delegation(conn, patch, patterns, pr_diff_set, delegation) do
+    case GitHub.get_pr_compare(conn, delegation.delegated_at_commit, patch.commit) do
+      {:ok, delta_files} ->
+        matched =
+          delta_files
+          |> Enum.map(& &1.filename)
+          |> Enum.filter(&MapSet.member?(pr_diff_set, &1))
+          |> Enum.find(&matches_any?(&1, patterns))
+
+        case matched do
+          nil -> :ok
+          path -> invalidate!(conn, patch, delegation, path)
+        end
+
+      {:error, reason} ->
+        Logger.warning(
+          "DelegationInvalidator: compare(delegation #{delegation.id}, head) failed: #{inspect(reason)}"
+        )
+
+        :ok
+    end
+  end
+
+  @doc false
+  def matches_any?(path, patterns) do
+    Enum.any?(patterns, fn pattern -> path == pattern or :glob.matches(path, pattern) end)
+  end
+
+  defp invalidate!(conn, patch, delegation, matched_path) do
+    Repo.delete!(delegation)
+
+    msg =
+      ":no_entry_sign: Delegation for @#{delegation.user.login} revoked: " <>
+        "the latest push touched `#{matched_path}`, which is listed in " <>
+        "`[delegation] invalidate_on_paths` in bors.toml. " <>
+        "Re-issue with `bors d=#{delegation.user.login} for=...` if appropriate."
+
+    try do
+      GitHub.post_comment!(conn, patch.pr_xref, msg)
+    rescue
+      e ->
+        Logger.warning(
+          "DelegationInvalidator: failed to comment on PR ##{patch.pr_xref}: #{Exception.message(e)}"
+        )
+    end
+  end
+end

--- a/lib/worker/delegation_invalidator.ex
+++ b/lib/worker/delegation_invalidator.ex
@@ -59,9 +59,11 @@ defmodule BorsNG.Worker.DelegationInvalidator do
 
   import Ecto.Query
 
+  alias BorsNG.Database.Context.Permission
   alias BorsNG.Database.Patch
   alias BorsNG.Database.Project
   alias BorsNG.Database.Repo
+  alias BorsNG.Database.User
   alias BorsNG.Database.UserPatchDelegation
   alias BorsNG.GitHub
   alias BorsNG.Worker.Batcher.GetBorsToml
@@ -130,10 +132,11 @@ defmodule BorsNG.Worker.DelegationInvalidator do
     # pr_diff is the same base...head diff for every delegation; fetch it once.
     # On synchronize a push always happened, so a delta worth filtering exists.
     filter = pr_diff_filter(conn, patch)
+    filter_fun = fn -> filter end
 
     revoked =
       Enum.flat_map(delegations, fn d ->
-        case classify_delegation(conn, patch, restrict, deny, filter, d) do
+        case classify_delegation(conn, patch, restrict, deny, filter_fun, d) do
           {:revoke, reason} -> [{d, reason}]
           # :ok and :unverifiable both leave the delegation in place here:
           # the push path fails open and relies on the next push (or the
@@ -151,6 +154,89 @@ defmodule BorsNG.Worker.DelegationInvalidator do
     :ok
   end
 
+  @doc """
+  Synchronous merge-time gate, called from the `bors r+` authorization path.
+
+  Re-checks the commenter's active delegation on the patch against the current
+  head and **fails closed**: returns `:deny` (after revoking + commenting, or
+  after a check it could not complete) so the caller refuses the approval.
+  Returns `:ok` when there is nothing to block — the commenter is a project
+  reviewer, has no active delegation, the config has no path lists, or the
+  delegation is still valid. See DELEGATION_INVALIDATION.md, "When invalidation
+  runs".
+  """
+  @spec verify_for_merge(Patch.t(), User.t()) :: :ok | :deny
+  def verify_for_merge(patch, user) do
+    patch = Repo.preload(patch, :project)
+
+    # Project reviewers hold approval rights independent of any delegation, so
+    # the delegation gate must not block (or revoke) them.
+    if Permission.get_permission(user, patch.project) == :reviewer do
+      :ok
+    else
+      case active_delegations_for(patch.id, user.id) do
+        [] ->
+          :ok
+
+        delegations ->
+          conn = Project.installation_connection(patch.project.repo_xref, Repo)
+
+          with {:ok, toml} <- GetBorsToml.get(conn, patch.into_branch),
+               restrict = toml.delegation_restrict_to_paths,
+               deny = toml.delegation_invalidate_on_paths,
+               true <- restrict != [] or deny != [] do
+            decide_merge(conn, patch, restrict, deny, delegations)
+          else
+            _ -> :ok
+          end
+      end
+    end
+  end
+
+  defp decide_merge(conn, patch, restrict, deny, delegations) do
+    # Lazy + computed at most once: a (user, patch) delegation is unique, and an
+    # empty delta short-circuits before the filter is ever forced.
+    filter_fun = fn -> pr_diff_filter(conn, patch) end
+
+    Enum.reduce_while(delegations, :ok, fn d, _acc ->
+      case classify_delegation(conn, patch, restrict, deny, filter_fun, d) do
+        :ok ->
+          {:cont, :ok}
+
+        {:revoke, reason} ->
+          Repo.delete_all(from(x in UserPatchDelegation, where: x.id == ^d.id))
+          post_revoke_comment(conn, patch, [{d, reason}])
+          {:halt, :deny}
+
+        # Couldn't read the delta: don't delete (we can't prove it's bad), but
+        # refuse this approval so a sensitive change can't slip through a failed
+        # check. A later `bors r+` re-runs the gate.
+        :unverifiable ->
+          safe_post(conn, patch.pr_xref, unverifiable_message())
+          {:halt, :deny}
+      end
+    end)
+  end
+
+  defp active_delegations_for(patch_id, user_id) do
+    now = NaiveDateTime.utc_now()
+
+    from(d in UserPatchDelegation,
+      where:
+        d.patch_id == ^patch_id and d.user_id == ^user_id and
+          not is_nil(d.delegated_at_commit) and
+          (is_nil(d.expires_at) or d.expires_at > ^now),
+      preload: [:user]
+    )
+    |> Repo.all()
+  end
+
+  defp unverifiable_message do
+    ":warning: Couldn't approve via delegation: bors was unable to read this pull " <>
+      "request's changes from GitHub just now, so it can't confirm the delegation is " <>
+      "still valid. Please try `bors r+` again in a moment."
+  end
+
   # Classify a single delegation against the current head.
   #
   #   :ok               delegation is still valid
@@ -159,8 +245,12 @@ defmodule BorsNG.Worker.DelegationInvalidator do
   #                     path skips/fails-open, the merge-time gate fails-closed)
   #
   # reason :: {:sensitive, path} | {:out_of_scope, path} | :too_large
+  #
+  # filter_fun is a thunk returning the pr_diff filter; it is forced only when a
+  # non-empty, non-truncated delta actually needs filtering, so an empty delta
+  # never triggers a pr_diff fetch (the merge-time short-circuit).
   @doc false
-  def classify_delegation(conn, patch, restrict, deny, filter, delegation) do
+  def classify_delegation(conn, patch, restrict, deny, filter_fun, delegation) do
     case GitHub.get_pr_compare(conn, delegation.delegated_at_commit, patch.commit) do
       # Empty delta: nothing changed since delegation, so nothing to check.
       {:ok, []} ->
@@ -174,7 +264,7 @@ defmodule BorsNG.Worker.DelegationInvalidator do
       {:ok, files} ->
         files
         |> Enum.map(& &1.filename)
-        |> apply_filter(filter)
+        |> apply_filter(filter_fun.())
         |> Enum.find_value(&classify_path(&1, restrict, deny))
         |> case do
           nil -> :ok

--- a/lib/worker/delegation_invalidator.ex
+++ b/lib/worker/delegation_invalidator.ex
@@ -334,7 +334,10 @@ defmodule BorsNG.Worker.DelegationInvalidator do
 
     with {:ok, toml} <- GetBorsToml.get(conn, patch.into_branch),
          [_ | _] = patterns <- toml.delegation_invalidate_on_paths,
-         {:ok, tree} <- GitHub.get_repo_tree(conn, patch.into_branch) do
+         # A truncated tree comes back as {:ok, {:truncated, _}}; match only a
+         # path list so truncation falls through to the catch-all and skips the
+         # lint rather than warning off an incomplete file set.
+         {:ok, tree} when is_list(tree) <- GitHub.get_repo_tree(conn, patch.into_branch) do
       case unmatched_paths(patterns, tree) do
         [] -> :ok
         bad -> post_lint_comment(conn, patch.pr_xref, bad)

--- a/lib/worker/delegation_invalidator.ex
+++ b/lib/worker/delegation_invalidator.ex
@@ -164,6 +164,71 @@ defmodule BorsNG.Worker.DelegationInvalidator do
     Enum.any?(patterns, fn pattern -> path == pattern or :glob.matches(path, pattern) end)
   end
 
+  @doc """
+  Returns the subset of `patterns` that match zero entries in `tree`.
+
+  Used by the bors-try lint to flag typos in `[delegation] invalidate_on_paths`
+  before they silently fail to protect anything.
+  """
+  @spec unmatched_paths([binary], [binary]) :: [binary]
+  def unmatched_paths(patterns, tree) do
+    Enum.reject(patterns, fn pattern ->
+      Enum.any?(tree, &matches_any?(&1, [pattern]))
+    end)
+  end
+
+  @doc """
+  Fire-and-forget lint of a patch's base-branch bors.toml. If any pattern in
+  `[delegation] invalidate_on_paths` matches zero files in the base branch's
+  HEAD tree, posts a single warning comment on the PR.
+  """
+  @spec lint_for_patch(Patch.id()) :: :ok
+  def lint_for_patch(patch_id) do
+    case Repo.one(from(p in Patch, where: p.id == ^patch_id, preload: :project)) do
+      nil ->
+        :ok
+
+      patch ->
+        try do
+          lint(patch)
+        rescue
+          e ->
+            Logger.warning(
+              "DelegationInvalidator.lint: crashed for patch #{patch_id}: #{Exception.message(e)}"
+            )
+
+            :ok
+        end
+    end
+  end
+
+  defp lint(patch) do
+    conn = Project.installation_connection(patch.project.repo_xref, Repo)
+
+    with {:ok, toml} <- GetBorsToml.get(conn, patch.into_branch),
+         [_ | _] = patterns <- toml.delegation_invalidate_on_paths,
+         {:ok, tree} <- GitHub.get_repo_tree(conn, patch.into_branch) do
+      case unmatched_paths(patterns, tree) do
+        [] -> :ok
+        bad -> post_lint_comment(conn, patch.pr_xref, bad)
+      end
+    else
+      _ -> :ok
+    end
+  end
+
+  defp post_lint_comment(conn, pr_xref, bad) do
+    rendered = bad |> Enum.map(&"`#{&1}`") |> Enum.join(", ")
+
+    msg =
+      ":warning: These patterns in `[delegation] invalidate_on_paths` match no files " <>
+        "in the base branch's HEAD: " <>
+        rendered <>
+        ". Check for typos — they may not protect what you intended."
+
+    safe_post(conn, pr_xref, msg)
+  end
+
   defp post_revoke_comment(conn, patch, [{delegation, matched_path}]) do
     msg =
       ":no_entry_sign: Delegation for @#{delegation.user.login} revoked: " <>

--- a/lib/worker/delegation_invalidator.ex
+++ b/lib/worker/delegation_invalidator.ex
@@ -44,6 +44,12 @@ defmodule BorsNG.Worker.DelegationInvalidator do
   A delegation is invalidated when any path in `relevant` matches any
   configured glob.
 
+  If the PR is rebased or force-pushed, `delegated_at_commit` may no longer
+  be an ancestor of the current head. The three-dot compare then anchors at
+  an earlier merge-base, widening `delta`. This errs toward over-revoking
+  (the safe direction for a security control): the worst case is a delegation
+  that must be re-issued, never one that silently survives a sensitive change.
+
   ## bors.toml provenance
 
   The `bors.toml` config is read from the PR's BASE branch, **not** from the
@@ -127,9 +133,12 @@ defmodule BorsNG.Worker.DelegationInvalidator do
           post_revoke_comment(conn, patch, revoked)
         end
 
-      {:error, reason} ->
+      # The GitHub client returns error tuples of several arities
+      # ({:error, action, status, params}, {:error, reason, action}, ...),
+      # never a bare {:error, reason}, so match anything that isn't {:ok, _}.
+      other ->
         Logger.warning(
-          "DelegationInvalidator: compare(base, head) failed for patch #{patch.id}: #{inspect(reason)}"
+          "DelegationInvalidator: compare(base, head) failed for patch #{patch.id}: #{inspect(other)}"
         )
 
         :ok
@@ -150,9 +159,11 @@ defmodule BorsNG.Worker.DelegationInvalidator do
           path -> [{delegation, path}]
         end
 
-      {:error, reason} ->
+      # See note in do_invalidate/4: the client never returns a bare
+      # {:error, reason}; match any non-{:ok, _} shape.
+      other ->
         Logger.warning(
-          "DelegationInvalidator: compare(delegation #{delegation.id}, head) failed: #{inspect(reason)}"
+          "DelegationInvalidator: compare(delegation #{delegation.id}, head) failed: #{inspect(other)}"
         )
 
         []
@@ -226,7 +237,14 @@ defmodule BorsNG.Worker.DelegationInvalidator do
         rendered <>
         ". Check for typos — they may not protect what you intended."
 
-    safe_post(conn, pr_xref, msg)
+    # The lint fires on every `bors try`, so dedup before posting. Match on the
+    # exact body: if the set of unmatched patterns changes, the message changes
+    # and we warn afresh. If reading comments fails, fall back to posting — a
+    # possible duplicate beats silently dropping the warning.
+    case GitHub.get_pr_comments(conn, pr_xref) do
+      {:ok, comments} -> unless msg in comments, do: safe_post(conn, pr_xref, msg)
+      _ -> safe_post(conn, pr_xref, msg)
+    end
   end
 
   defp post_revoke_comment(conn, patch, [{delegation, matched_path}]) do

--- a/lib/worker/delegation_invalidator.ex
+++ b/lib/worker/delegation_invalidator.ex
@@ -68,6 +68,13 @@ defmodule BorsNG.Worker.DelegationInvalidator do
 
   require Logger
 
+  # GitHub's per-endpoint changed-file ceilings. Reaching either means the file
+  # list may be incomplete, which we treat as truncation. See
+  # DELEGATION_INVALIDATION.md, "GitHub API file ceilings": compare(base...head)
+  # caps at 300 with no file pagination; pulls/{n}/files caps at 3000.
+  @compare_file_cap 300
+  @pr_files_cap 3000
+
   @doc """
   Fire-and-forget entry point. Safe to call from a supervised task. Loads
   the patch (with its project) fresh from the DB to avoid stale state.
@@ -101,8 +108,10 @@ defmodule BorsNG.Worker.DelegationInvalidator do
       conn = Project.installation_connection(patch.project.repo_xref, Repo)
 
       with {:ok, toml} <- GetBorsToml.get(conn, patch.into_branch),
-           [_ | _] = patterns <- toml.delegation_invalidate_on_paths do
-        do_invalidate(conn, patch, patterns, delegations)
+           restrict = toml.delegation_restrict_to_paths,
+           deny = toml.delegation_invalidate_on_paths,
+           true <- restrict != [] or deny != [] do
+        do_invalidate(conn, patch, restrict, deny, delegations)
       else
         _ -> :ok
       end
@@ -117,56 +126,107 @@ defmodule BorsNG.Worker.DelegationInvalidator do
     |> Repo.all()
   end
 
-  defp do_invalidate(conn, patch, patterns, delegations) do
-    case GitHub.get_pr_compare(conn, patch.into_branch, patch.commit) do
-      {:ok, pr_diff_files} ->
-        pr_diff_set = MapSet.new(pr_diff_files, & &1.filename)
+  defp do_invalidate(conn, patch, restrict, deny, delegations) do
+    # pr_diff is the same base...head diff for every delegation; fetch it once.
+    # On synchronize a push always happened, so a delta worth filtering exists.
+    filter = pr_diff_filter(conn, patch)
 
-        revoked =
-          Enum.flat_map(delegations, fn d ->
-            matching_path(conn, patch, patterns, pr_diff_set, d)
-          end)
+    revoked =
+      Enum.flat_map(delegations, fn d ->
+        case classify_delegation(conn, patch, restrict, deny, filter, d) do
+          {:revoke, reason} -> [{d, reason}]
+          # :ok and :unverifiable both leave the delegation in place here:
+          # the push path fails open and relies on the next push (or the
+          # merge-time gate) to catch anything this run could not verify.
+          _ -> []
+        end
+      end)
 
-        if revoked != [] do
-          ids = Enum.map(revoked, fn {d, _path} -> d.id end)
-          Repo.delete_all(from(d in UserPatchDelegation, where: d.id in ^ids))
-          post_revoke_comment(conn, patch, revoked)
+    if revoked != [] do
+      ids = Enum.map(revoked, fn {d, _reason} -> d.id end)
+      Repo.delete_all(from(d in UserPatchDelegation, where: d.id in ^ids))
+      post_revoke_comment(conn, patch, revoked)
+    end
+
+    :ok
+  end
+
+  # Classify a single delegation against the current head.
+  #
+  #   :ok               delegation is still valid
+  #   {:revoke, reason} revoke it; reason drives the comment
+  #   :unverifiable     the delta compare failed; the caller decides (the push
+  #                     path skips/fails-open, the merge-time gate fails-closed)
+  #
+  # reason :: {:sensitive, path} | {:out_of_scope, path} | :too_large
+  @doc false
+  def classify_delegation(conn, patch, restrict, deny, filter, delegation) do
+    case GitHub.get_pr_compare(conn, delegation.delegated_at_commit, patch.commit) do
+      # Empty delta: nothing changed since delegation, so nothing to check.
+      {:ok, []} ->
+        :ok
+
+      # Hit the compare cap: we cannot enumerate the post-delegation changes,
+      # so a sensitive/out-of-scope path may be hidden. Fail safe.
+      {:ok, files} when length(files) >= @compare_file_cap ->
+        {:revoke, :too_large}
+
+      {:ok, files} ->
+        files
+        |> Enum.map(& &1.filename)
+        |> apply_filter(filter)
+        |> Enum.find_value(&classify_path(&1, restrict, deny))
+        |> case do
+          nil -> :ok
+          reason -> {:revoke, reason}
         end
 
-      # The GitHub client returns error tuples of several arities
-      # ({:error, action, status, params}, {:error, reason, action}, ...),
-      # never a bare {:error, reason}, so match anything that isn't {:ok, _}.
+      # The GitHub client returns error tuples of several arities, never a bare
+      # {:error, reason}, so match anything that isn't an {:ok, _} we handle.
       other ->
         Logger.warning(
-          "DelegationInvalidator: compare(base, head) failed for patch #{patch.id}: #{inspect(other)}"
+          "DelegationInvalidator: delta compare failed for delegation #{delegation.id}: #{inspect(other)}"
         )
 
-        :ok
+        :unverifiable
     end
   end
 
-  defp matching_path(conn, patch, patterns, pr_diff_set, delegation) do
-    case GitHub.get_pr_compare(conn, delegation.delegated_at_commit, patch.commit) do
-      {:ok, delta_files} ->
-        matched =
-          delta_files
-          |> Enum.map(& &1.filename)
-          |> Enum.filter(&MapSet.member?(pr_diff_set, &1))
-          |> Enum.find(&matches_any?(&1, patterns))
+  # The PR's own file list, used to filter base-merge noise out of a delta.
+  # {:filter, set} when fully known; :no_filter when truncated or unavailable,
+  # in which case the delta is evaluated directly (delta-only fallback, which
+  # can only over-revoke). See DELEGATION_INVALIDATION.md, "Truncation policy".
+  @doc false
+  def pr_diff_filter(conn, patch) do
+    case GitHub.get_pr_files(conn, patch.pr_xref) do
+      {:ok, files} when length(files) < @pr_files_cap ->
+        {:filter, MapSet.new(files, & &1.filename)}
 
-        case matched do
-          nil -> []
-          path -> [{delegation, path}]
-        end
+      {:ok, _capped} ->
+        :no_filter
 
-      # See note in do_invalidate/4: the client never returns a bare
-      # {:error, reason}; match any non-{:ok, _} shape.
       other ->
         Logger.warning(
-          "DelegationInvalidator: compare(delegation #{delegation.id}, head) failed: #{inspect(other)}"
+          "DelegationInvalidator: pr_diff (get_pr_files) failed for patch #{patch.id}: #{inspect(other)}"
         )
 
-        []
+        :no_filter
+    end
+  end
+
+  defp apply_filter(filenames, :no_filter), do: filenames
+
+  defp apply_filter(filenames, {:filter, set}),
+    do: Enum.filter(filenames, &MapSet.member?(set, &1))
+
+  # Deny-list overrides allow-list; an unset allow-list imposes no scope. See
+  # DELEGATION_INVALIDATION.md, "Deciding what's acceptable". Returns nil when
+  # the path is acceptable.
+  defp classify_path(path, restrict, deny) do
+    cond do
+      matches_any?(path, deny) -> {:sensitive, path}
+      restrict != [] and not matches_any?(path, restrict) -> {:out_of_scope, path}
+      true -> nil
     end
   end
 
@@ -247,12 +307,11 @@ defmodule BorsNG.Worker.DelegationInvalidator do
     end
   end
 
-  defp post_revoke_comment(conn, patch, [{delegation, matched_path}]) do
+  defp post_revoke_comment(conn, patch, [{delegation, reason}]) do
     msg =
-      ":no_entry_sign: Delegation for @#{delegation.user.login} revoked: " <>
-        "the latest push touched `#{matched_path}`, which is listed in " <>
-        "`[delegation] invalidate_on_paths` in bors.toml. " <>
-        "Re-issue with `bors d=#{delegation.user.login} for=...` if appropriate."
+      ":no_entry_sign: Delegation for @#{delegation.user.login} revoked: the latest push " <>
+        reason_clause(reason) <>
+        ". Re-issue with `bors d=#{delegation.user.login} for=...` if appropriate."
 
     safe_post(conn, patch.pr_xref, msg)
   end
@@ -260,17 +319,29 @@ defmodule BorsNG.Worker.DelegationInvalidator do
   defp post_revoke_comment(conn, patch, revoked) do
     bullets =
       revoked
-      |> Enum.map(fn {d, path} -> "- @#{d.user.login} — touched `#{path}`" end)
+      |> Enum.map(fn {d, reason} -> "- @#{d.user.login} — #{reason_clause(reason)}" end)
       |> Enum.join("\n")
 
     msg =
-      ":no_entry_sign: Delegations revoked because the latest push touched paths " <>
-        "listed in `[delegation] invalidate_on_paths` in bors.toml:\n\n" <>
+      ":no_entry_sign: Delegations revoked because the latest push changed paths they " <>
+        "no longer cover:\n\n" <>
         bullets <>
         "\n\nRe-issue with `bors d=...` if appropriate."
 
     safe_post(conn, patch.pr_xref, msg)
   end
+
+  # Renders the reason half of a revoke comment, following "the latest push ".
+  defp reason_clause({:sensitive, path}),
+    do: "touched `#{path}`, which is listed in `[delegation] invalidate_on_paths` in bors.toml"
+
+  defp reason_clause({:out_of_scope, path}),
+    do:
+      "touched `#{path}`, which is outside the paths this delegation covers " <>
+        "(`[delegation] restrict_to_paths` in bors.toml)"
+
+  defp reason_clause(:too_large),
+    do: "changed too many files for bors to check the full list against the configured paths"
 
   defp safe_post(conn, pr_xref, msg) do
     GitHub.post_comment!(conn, pr_xref, msg)

--- a/lib/worker/delegation_invalidator.ex
+++ b/lib/worker/delegation_invalidator.ex
@@ -63,12 +63,12 @@ defmodule BorsNG.Worker.DelegationInvalidator do
   require Logger
 
   @doc """
-  Fire-and-forget entry point. Safe to call from `Task.start`. Loads the
-  patch fresh from the DB to avoid stale state.
+  Fire-and-forget entry point. Safe to call from a supervised task. Loads
+  the patch (with its project) fresh from the DB to avoid stale state.
   """
   @spec invalidate_for_patch(Patch.id()) :: :ok
   def invalidate_for_patch(patch_id) do
-    case Repo.get(Patch, patch_id) do
+    case Repo.one(from(p in Patch, where: p.id == ^patch_id, preload: :project)) do
       nil ->
         :ok
 
@@ -92,8 +92,7 @@ defmodule BorsNG.Worker.DelegationInvalidator do
     if delegations == [] do
       :ok
     else
-      project = Repo.get!(Project, patch.project_id)
-      conn = Project.installation_connection(project.repo_xref, Repo)
+      conn = Project.installation_connection(patch.project.repo_xref, Repo)
 
       with {:ok, toml} <- GetBorsToml.get(conn, patch.into_branch),
            [_ | _] = patterns <- toml.delegation_invalidate_on_paths do
@@ -117,9 +116,16 @@ defmodule BorsNG.Worker.DelegationInvalidator do
       {:ok, pr_diff_files} ->
         pr_diff_set = MapSet.new(pr_diff_files, & &1.filename)
 
-        Enum.each(delegations, fn d ->
-          check_delegation(conn, patch, patterns, pr_diff_set, d)
-        end)
+        revoked =
+          Enum.flat_map(delegations, fn d ->
+            matching_path(conn, patch, patterns, pr_diff_set, d)
+          end)
+
+        if revoked != [] do
+          ids = Enum.map(revoked, fn {d, _path} -> d.id end)
+          Repo.delete_all(from(d in UserPatchDelegation, where: d.id in ^ids))
+          post_revoke_comment(conn, patch, revoked)
+        end
 
       {:error, reason} ->
         Logger.warning(
@@ -130,7 +136,7 @@ defmodule BorsNG.Worker.DelegationInvalidator do
     end
   end
 
-  defp check_delegation(conn, patch, patterns, pr_diff_set, delegation) do
+  defp matching_path(conn, patch, patterns, pr_diff_set, delegation) do
     case GitHub.get_pr_compare(conn, delegation.delegated_at_commit, patch.commit) do
       {:ok, delta_files} ->
         matched =
@@ -140,8 +146,8 @@ defmodule BorsNG.Worker.DelegationInvalidator do
           |> Enum.find(&matches_any?(&1, patterns))
 
         case matched do
-          nil -> :ok
-          path -> invalidate!(conn, patch, delegation, path)
+          nil -> []
+          path -> [{delegation, path}]
         end
 
       {:error, reason} ->
@@ -149,7 +155,7 @@ defmodule BorsNG.Worker.DelegationInvalidator do
           "DelegationInvalidator: compare(delegation #{delegation.id}, head) failed: #{inspect(reason)}"
         )
 
-        :ok
+        []
     end
   end
 
@@ -158,22 +164,37 @@ defmodule BorsNG.Worker.DelegationInvalidator do
     Enum.any?(patterns, fn pattern -> path == pattern or :glob.matches(path, pattern) end)
   end
 
-  defp invalidate!(conn, patch, delegation, matched_path) do
-    Repo.delete!(delegation)
-
+  defp post_revoke_comment(conn, patch, [{delegation, matched_path}]) do
     msg =
       ":no_entry_sign: Delegation for @#{delegation.user.login} revoked: " <>
         "the latest push touched `#{matched_path}`, which is listed in " <>
         "`[delegation] invalidate_on_paths` in bors.toml. " <>
         "Re-issue with `bors d=#{delegation.user.login} for=...` if appropriate."
 
-    try do
-      GitHub.post_comment!(conn, patch.pr_xref, msg)
-    rescue
-      e ->
-        Logger.warning(
-          "DelegationInvalidator: failed to comment on PR ##{patch.pr_xref}: #{Exception.message(e)}"
-        )
-    end
+    safe_post(conn, patch.pr_xref, msg)
+  end
+
+  defp post_revoke_comment(conn, patch, revoked) do
+    bullets =
+      revoked
+      |> Enum.map(fn {d, path} -> "- @#{d.user.login} — touched `#{path}`" end)
+      |> Enum.join("\n")
+
+    msg =
+      ":no_entry_sign: Delegations revoked because the latest push touched paths " <>
+        "listed in `[delegation] invalidate_on_paths` in bors.toml:\n\n" <>
+        bullets <>
+        "\n\nRe-issue with `bors d=...` if appropriate."
+
+    safe_post(conn, patch.pr_xref, msg)
+  end
+
+  defp safe_post(conn, pr_xref, msg) do
+    GitHub.post_comment!(conn, pr_xref, msg)
+  rescue
+    e ->
+      Logger.warning(
+        "DelegationInvalidator: failed to comment on PR ##{pr_xref}: #{Exception.message(e)}"
+      )
   end
 end

--- a/lib/worker/delegation_invalidator.ex
+++ b/lib/worker/delegation_invalidator.ex
@@ -1,60 +1,26 @@
 defmodule BorsNG.Worker.DelegationInvalidator do
   @moduledoc """
-  Invalidates PR delegations when new author commits touch paths configured
-  in bors.toml's `[delegation] invalidate_on_paths = [...]` list.
+  Invalidates PR delegations when new author work touches paths a project has
+  restricted, and re-checks delegations at merge time.
 
-  ## bors.toml syntax
+  Configured under `[delegation]` in `bors.toml` (read from the PR's BASE
+  branch, so a PR cannot disable it by editing its own copy):
 
       [delegation]
-      invalidate_on_paths = [
-        "Cargo.toml",
-        "Cargo.lock",
-        ".github/**",
-        "deps/**",
-      ]
+      restrict_to_paths   = ["src/**"]         # allow-list: delegation covers only these
+      invalidate_on_paths = ["src/crypto.rs"]  # deny-list: always revoke (overrides the allow-list)
 
-  Each entry is a glob pattern matched against repository-relative paths
-  (forward slashes, no leading `./`). Matching uses Erlang's `:glob` module,
-  which differs from gitignore in two important ways:
+  Each entry is a glob matched against repository-relative paths via Erlang's
+  `:glob`, which differs from gitignore: `*` matches across `/` (so
+  `.github/*` and `.github/**` are equivalent, and `?` matches a single
+  character), and patterns are anchored — `Cargo.toml` matches only the
+  top-level file; use `**/Cargo.toml` to match anywhere in the tree.
 
-    * `*` matches any sequence of characters **including `/`**, so
-      `.github/*` and `.github/**` are equivalent. There is no need to write
-      `**` to recurse into subdirectories.
-    * `?` matches a single character (not directory-aware).
-
-  Patterns are anchored: `Cargo.toml` matches only the top-level file, not
-  `foo/Cargo.toml`. Use `**/Cargo.toml` to match anywhere in the tree.
-
-  ## Triggering and false-positive avoidance
-
-  Runs from the `synchronize` webhook. To avoid false positives from
-  GitHub's "Update branch" button (which also fires `synchronize`), we use
-  the intersection of two compares to isolate "new author work since the
-  delegation was issued":
-
-      delta    = files in `compare(delegated_at_commit, current_head)`
-      pr_diff  = files in `compare(base_branch, current_head)`   (three-dot)
-      relevant = delta ∩ pr_diff
-
-  `pr_diff` is a three-dot compare anchored at the base branch, so it
-  represents only content the author has added in the PR (base-only content
-  is naturally excluded). The intersection drops anything in `delta` that
-  came from a base-merge.
-
-  A delegation is invalidated when any path in `relevant` matches any
-  configured glob.
-
-  If the PR is rebased or force-pushed, `delegated_at_commit` may no longer
-  be an ancestor of the current head. The three-dot compare then anchors at
-  an earlier merge-base, widening `delta`. This errs toward over-revoking
-  (the safe direction for a security control): the worst case is a delegation
-  that must be re-issued, never one that silently survives a sensitive change.
-
-  ## bors.toml provenance
-
-  The `bors.toml` config is read from the PR's BASE branch, **not** from the
-  PR head. A PR therefore cannot disable invalidation by editing its own
-  copy of `bors.toml`.
+  The full design — the two-compare model and "Update branch" noise filter,
+  the allow-list/deny-list acceptability rule, GitHub's compare/PR-files
+  ceilings and the resulting truncation policy, the synchronize-time
+  (fail-open) versus merge-time (fail-closed) checks, and the user-facing
+  messages — lives in `DELEGATION_INVALIDATION.md` at the repo root.
   """
 
   import Ecto.Query

--- a/test/batcher/batcher_test.exs
+++ b/test/batcher/batcher_test.exs
@@ -2922,6 +2922,75 @@ defmodule BorsNG.Worker.BatcherTest do
            }
   end
 
+  test "refuses to merge a head that moved past patch.commit (race guard)", %{proj: proj} do
+    # Integrity backstop for the delegation merge-time gate: the patch was
+    # approved/gated against commit "N", but the live PR head has since advanced
+    # to "O" (e.g. a `synchronize` bors never processed). Staging must refuse to
+    # merge the unverified head rather than merge it. See batcher.ex's race
+    # guard and DELEGATION_INVALIDATION.md, "Missed-push window".
+    GitHub.ServerMock.put_state(%{
+      {{:installation, 91}, 14} => %{
+        branches: %{"master" => "ini", "staging" => "", "staging.tmp" => ""},
+        commits: %{},
+        comments: %{1 => []},
+        statuses: %{"iniN" => %{}},
+        files: %{"staging.tmp" => %{"bors.toml" => ~s/status = [ "ci" ]/}},
+        pulls: %{
+          1 => %Pr{
+            number: 1,
+            title: "Test",
+            body: "Mess",
+            state: :open,
+            base_ref: "master",
+            head_sha: "O",
+            head_ref: "update",
+            base_repo_id: 14,
+            head_repo_id: 14,
+            merged: false
+          }
+        },
+        pr_commits: %{
+          1 => [
+            %GitHub.Commit{sha: "1234", author_name: "a", author_email: "e"}
+          ]
+        }
+      }
+    })
+
+    patch =
+      %Patch{
+        project_id: proj.id,
+        pr_xref: 1,
+        commit: "N",
+        into_branch: "master"
+      }
+      |> Repo.insert!()
+
+    Batcher.handle_cast({:reviewed, patch.id, "rvr"}, proj.id)
+
+    # Force a poll so the batch leaves :waiting and attempts to stage.
+    batch = Repo.get_by!(Batch, project_id: proj.id)
+
+    batch
+    |> Batch.changeset(%{last_polled: 0})
+    |> Repo.update!()
+
+    Batcher.handle_info({:poll, :once}, proj.id)
+
+    # The race guard fires: the batch errors out via the :race path (not some
+    # other failure) instead of merging.
+    batch = Repo.get_by!(Batch, project_id: proj.id)
+    assert batch.state == :error
+
+    state = GitHub.ServerMock.get_state()[{{:installation, 91}, 14}]
+    assert "Synchronization error!" in state.comments[1]
+    # master never advanced and the PR was never merged — the moved head "O"
+    # (which nothing verified) did not reach the target branch.
+    assert state.branches["master"] == "ini"
+    refute state.pulls[1].merged
+    assert state.statuses["O"] == nil
+  end
+
   test "merge conflict with master", %{proj: proj} do
     # Projects are created with a "waiting" state
     GitHub.ServerMock.put_state(%{

--- a/test/batcher/bors_toml_test.exs
+++ b/test/batcher/bors_toml_test.exs
@@ -173,4 +173,45 @@ defmodule BatcherBorsTomlTest do
     r = BorsToml.new(~s/status = ["exl"]\n[delegation]\ninvalidate_on_paths = ["ok", 42]/)
     assert r == {:error, :delegation_invalidate_on_paths}
   end
+
+  test "defaults delegation_restrict_to_paths to []" do
+    {:ok, toml} = BorsToml.new(~s/status = ["exl"]/)
+    assert toml.delegation_restrict_to_paths == []
+  end
+
+  test "parses delegation.restrict_to_paths" do
+    cfg = ~s"""
+    status = ["exl"]
+    [delegation]
+    restrict_to_paths = ["src/**", "tests/**"]
+    """
+
+    {:ok, toml} = BorsToml.new(cfg)
+
+    assert toml.delegation_restrict_to_paths == ["src/**", "tests/**"]
+  end
+
+  test "parses delegation.restrict_to_paths alongside invalidate_on_paths" do
+    cfg = ~s"""
+    status = ["exl"]
+    [delegation]
+    restrict_to_paths = ["src/**"]
+    invalidate_on_paths = ["src/crypto.rs"]
+    """
+
+    {:ok, toml} = BorsToml.new(cfg)
+
+    assert toml.delegation_restrict_to_paths == ["src/**"]
+    assert toml.delegation_invalidate_on_paths == ["src/crypto.rs"]
+  end
+
+  test "rejects non-list delegation.restrict_to_paths" do
+    r = BorsToml.new(~s/status = ["exl"]\n[delegation]\nrestrict_to_paths = "src"/)
+    assert r == {:error, :delegation_restrict_to_paths}
+  end
+
+  test "rejects non-string elements in delegation.restrict_to_paths" do
+    r = BorsToml.new(~s/status = ["exl"]\n[delegation]\nrestrict_to_paths = ["ok", 42]/)
+    assert r == {:error, :delegation_restrict_to_paths}
+  end
 end

--- a/test/batcher/bors_toml_test.exs
+++ b/test/batcher/bors_toml_test.exs
@@ -142,4 +142,35 @@ defmodule BatcherBorsTomlTest do
     r = BorsToml.new(~s/status = ["exl"]\ndelegation = "nope"/)
     assert r == {:error, :delegation_default_expiry_sec}
   end
+
+  test "defaults delegation_invalidate_on_paths to []" do
+    {:ok, toml} = BorsToml.new(~s/status = ["exl"]/)
+    assert toml.delegation_invalidate_on_paths == []
+  end
+
+  test "parses delegation.invalidate_on_paths" do
+    cfg = ~s"""
+    status = ["exl"]
+    [delegation]
+    invalidate_on_paths = ["Cargo.toml", ".github/**", "src/critical/*.rs"]
+    """
+
+    {:ok, toml} = BorsToml.new(cfg)
+
+    assert toml.delegation_invalidate_on_paths == [
+             "Cargo.toml",
+             ".github/**",
+             "src/critical/*.rs"
+           ]
+  end
+
+  test "rejects non-list delegation.invalidate_on_paths" do
+    r = BorsToml.new(~s/status = ["exl"]\n[delegation]\ninvalidate_on_paths = "Cargo.toml"/)
+    assert r == {:error, :delegation_invalidate_on_paths}
+  end
+
+  test "rejects non-string elements in delegation.invalidate_on_paths" do
+    r = BorsToml.new(~s/status = ["exl"]\n[delegation]\ninvalidate_on_paths = ["ok", 42]/)
+    assert r == {:error, :delegation_invalidate_on_paths}
+  end
 end

--- a/test/batcher/bors_toml_test.exs
+++ b/test/batcher/bors_toml_test.exs
@@ -214,4 +214,39 @@ defmodule BatcherBorsTomlTest do
     r = BorsToml.new(~s/status = ["exl"]\n[delegation]\nrestrict_to_paths = ["ok", 42]/)
     assert r == {:error, :delegation_restrict_to_paths}
   end
+
+  test "rejects an uncompilable glob in delegation.invalidate_on_paths" do
+    # `:glob.matches/2` raises badarg on a non-terminated character class; reject
+    # it at parse time so the synchronous merge-time gate can't crash on it.
+    r =
+      BorsToml.new(~S"""
+      status = ["exl"]
+      [delegation]
+      invalidate_on_paths = ["src/["]
+      """)
+
+    assert r == {:error, :delegation_invalidate_on_paths}
+  end
+
+  test "rejects an uncompilable glob in delegation.restrict_to_paths" do
+    r =
+      BorsToml.new(~S"""
+      status = ["exl"]
+      [delegation]
+      restrict_to_paths = ["src/["]
+      """)
+
+    assert r == {:error, :delegation_restrict_to_paths}
+  end
+
+  test "accepts valid glob patterns in the delegation path lists" do
+    {:ok, toml} =
+      BorsToml.new(~S"""
+      status = ["exl"]
+      [delegation]
+      restrict_to_paths = ["src/**/*.rs", "a?b"]
+      """)
+
+    assert toml.delegation_restrict_to_paths == ["src/**/*.rs", "a?b"]
+  end
 end

--- a/test/batcher/message_test.exs
+++ b/test/batcher/message_test.exs
@@ -20,6 +20,42 @@ defmodule BorsNG.Worker.BatcherMessageTest do
     assert expected_message == actual_message
   end
 
+  test "every bors.toml validation error key renders to a comment, not a crash" do
+    # These are every key BorsToml/GetBorsToml can emit. Each must produce a
+    # string; an unhandled key used to raise FunctionClauseError and crash the
+    # batcher instead of posting a "Configuration problem" comment.
+    keys = [
+      :status,
+      :block_labels,
+      :pr_status,
+      :timeout_sec,
+      :prerun_timeout_sec,
+      :required_approvals,
+      :cut_body_after,
+      :committer_details,
+      :commit_title,
+      :max_batch_size,
+      :delegation_default_expiry_sec,
+      :delegation_invalidate_on_paths,
+      :delegation_restrict_to_paths,
+      :empty_config,
+      :parse_failed,
+      :fetch_failed
+    ]
+
+    for key <- keys do
+      message = Message.generate_bors_toml_error(key)
+      assert is_binary(message)
+      assert String.contains?(message, "bors.toml")
+    end
+  end
+
+  test "unknown bors.toml error keys fall back to the catch-all renderer" do
+    message = Message.generate_bors_toml_error(:some_future_key)
+    assert is_binary(message)
+    assert String.contains?(message, "bors.toml")
+  end
+
   test "generate retry message" do
     expected_message = "Build failed (retrying...):\n  * stat"
     example_statuses = [%{url: nil, identifier: "stat"}]

--- a/test/batcher/message_test.exs
+++ b/test/batcher/message_test.exs
@@ -20,33 +20,37 @@ defmodule BorsNG.Worker.BatcherMessageTest do
     assert expected_message == actual_message
   end
 
-  test "every bors.toml validation error key renders to a comment, not a crash" do
-    # These are every key BorsToml/GetBorsToml can emit. Each must produce a
-    # string; an unhandled key used to raise FunctionClauseError and crash the
-    # batcher instead of posting a "Configuration problem" comment.
-    keys = [
-      :status,
-      :block_labels,
-      :pr_status,
-      :timeout_sec,
-      :prerun_timeout_sec,
-      :required_approvals,
-      :cut_body_after,
-      :committer_details,
-      :commit_title,
-      :max_batch_size,
-      :delegation_default_expiry_sec,
-      :delegation_invalidate_on_paths,
-      :delegation_restrict_to_paths,
-      :empty_config,
-      :parse_failed,
-      :fetch_failed
-    ]
+  test "every bors.toml error key has an explicit, friendly renderer" do
+    # Single source of truth: BorsToml's @type err (introspected below), plus
+    # the fetch-layer-only :fetch_failed. Adding a new validation key extends
+    # that type, which makes this test require an explicit
+    # generate_bors_toml_error/1 clause for it. Forget the clause and the key
+    # falls through to the catch-all, which this test detects and fails on — so
+    # a new key can't silently ship with a generic message (or, before the
+    # catch-all existed, crash the batcher).
+    keys = bors_toml_error_keys() ++ [:fetch_failed]
+
+    # Reconstruct the catch-all's output for a key by templating from a sentinel
+    # that has no explicit clause, so this stays correct if the catch-all
+    # wording changes.
+    sentinel = :__unhandled_sentinel_key__
+
+    catch_all = fn key ->
+      String.replace(
+        Message.generate_bors_toml_error(sentinel),
+        to_string(sentinel),
+        to_string(key)
+      )
+    end
 
     for key <- keys do
       message = Message.generate_bors_toml_error(key)
       assert is_binary(message)
       assert String.contains?(message, "bors.toml")
+
+      refute message == catch_all.(key),
+             "#{inspect(key)} has no explicit generate_bors_toml_error/1 clause; it falls " <>
+               "through to the catch-all. Add a friendly message in message.ex."
     end
   end
 
@@ -54,6 +58,15 @@ defmodule BorsNG.Worker.BatcherMessageTest do
     message = Message.generate_bors_toml_error(:some_future_key)
     assert is_binary(message)
     assert String.contains?(message, "bors.toml")
+  end
+
+  # Atom members of BorsToml's `@type err` union, read from the compiled
+  # typespec so this list can't drift from the source of truth.
+  defp bors_toml_error_keys do
+    {:ok, types} = Code.Typespec.fetch_types(BorsNG.Worker.Batcher.BorsToml)
+    {_, {:err, definition, []}} = Enum.find(types, fn {_, {name, _, _}} -> name == :err end)
+    {:type, _, :union, members} = definition
+    Enum.map(members, fn {:atom, _, atom} -> atom end)
   end
 
   test "generate retry message" do

--- a/test/command_test.exs
+++ b/test/command_test.exs
@@ -340,6 +340,71 @@ defmodule BorsNG.CommandTest do
     ]
   end
 
+  test "explicit-duration delegate also backfills a lingering forever-delegation",
+       %{proj: proj} do
+    # A pre-existing no-expiry ("forever") delegation should be stamped with the
+    # bors.toml default whenever someone delegates on the patch — even when the
+    # current command carries its own explicit `for=` duration. This pins that
+    # reconcile_default_expiry runs on the explicit-duration path, not only the
+    # no-`for=` path it used to be limited to.
+    pr = %BorsNG.GitHub.Pr{
+      number: 1,
+      title: "Test",
+      body: "Mess",
+      state: :open,
+      base_ref: "master",
+      head_sha: "00000001",
+      head_ref: "update",
+      base_repo_id: 13,
+      head_repo_id: 13,
+      user: %{id: 2, login: "pr_author"}
+    }
+
+    GitHub.ServerMock.put_state(%{
+      {{:installation, 91}, 14} => %{
+        branches: %{},
+        comments: %{1 => ["bors delegate+ for=2w"]},
+        statuses: %{},
+        files: %{"master" => %{"bors.toml" => delegation_toml()}},
+        pulls: %{1 => pr}
+      }
+    })
+
+    {:ok, owner} =
+      Repo.insert(%BorsNG.Database.User{user_xref: 1, is_admin: true, login: "repo_owner"})
+
+    {:ok, patch} =
+      Repo.insert(%BorsNG.Database.Patch{
+        project_id: proj.id,
+        pr_xref: 1,
+        commit: "N",
+        into_branch: "master"
+      })
+
+    Repo.insert(%BorsNG.Database.LinkUserProject{user_id: owner.id, project_id: proj.id})
+
+    # A lingering forever-delegation (no expiry) for a different user.
+    {:ok, bob} = Repo.insert(%BorsNG.Database.User{user_xref: 99, login: "bob"})
+
+    BorsNG.Database.Context.Permission.delegate(bob, patch, delegated_at_commit: "old")
+
+    c = %Command{
+      project: proj,
+      commenter: owner,
+      comment: "bors delegate+ for=2w",
+      pr_xref: 1
+    }
+
+    Command.run(c)
+
+    bob_delegation =
+      Repo.get_by!(BorsNG.Database.UserPatchDelegation, user_id: bob.id, patch_id: patch.id)
+
+    # Backfilled from forever to the toml default, despite the command's
+    # explicit for=2w applying only to the new delegatee.
+    refute is_nil(bob_delegation.expires_at)
+  end
+
   test_with_params "delegate= delegates properly", %{proj: proj}, fn delegate_command ->
     pr = %BorsNG.GitHub.Pr{
       number: 1,

--- a/test/command_test.exs
+++ b/test/command_test.exs
@@ -1259,6 +1259,67 @@ defmodule BorsNG.CommandTest do
     refute Enum.any?(comments, &String.contains?(&1, "revoke this delegation"))
   end
 
+  test "delegate+ describes the delegated scope and the too-many-files caveat", %{proj: proj} do
+    pr = %BorsNG.GitHub.Pr{
+      number: 1,
+      title: "Test",
+      body: "Mess",
+      state: :open,
+      base_ref: "master",
+      head_sha: "00000001",
+      head_ref: "update",
+      base_repo_id: 13,
+      head_repo_id: 13,
+      user: %{id: 2, login: "pr_author"}
+    }
+
+    toml = ~s"""
+    status = ["ci"]
+    [delegation]
+    default_expiry_sec = #{24 * 60 * 60}
+    restrict_to_paths = ["src/**"]
+    """
+
+    GitHub.ServerMock.put_state(%{
+      {{:installation, 91}, 14} => %{
+        branches: %{},
+        comments: %{1 => ["bors delegate+"]},
+        statuses: %{},
+        files: %{"master" => %{"bors.toml" => toml}},
+        pulls: %{1 => pr}
+      }
+    })
+
+    {:ok, user} =
+      Repo.insert(%BorsNG.Database.User{user_xref: 1, is_admin: true, login: "owner"})
+
+    {:ok, _} =
+      Repo.insert(%BorsNG.Database.Patch{
+        project_id: proj.id,
+        pr_xref: 1,
+        commit: "headsha123",
+        into_branch: "master"
+      })
+
+    Repo.insert(%BorsNG.Database.LinkUserProject{user_id: user.id, project_id: proj.id})
+
+    Command.run(%Command{
+      project: proj,
+      commenter: user,
+      comment: "bors delegate+",
+      pr_xref: 1
+    })
+
+    state = GitHub.ServerMock.get_state()
+    comments = get_in(state, [{{:installation, 91}, 14}, :comments, 1])
+
+    assert Enum.any?(comments, fn c ->
+             String.contains?(c, "only covers changes within") and String.contains?(c, "`src/**`")
+           end)
+
+    assert Enum.any?(comments, &String.contains?(&1, "too many files"))
+  end
+
   test "re-delegating the same user replaces expires_at", %{proj: proj} do
     pr = %BorsNG.GitHub.Pr{
       number: 1,

--- a/test/command_test.exs
+++ b/test/command_test.exs
@@ -1148,6 +1148,117 @@ defmodule BorsNG.CommandTest do
     assert d.delegated_at_commit == "00000001"
   end
 
+  test "delegate+ echoes invalidate_on_paths in the success comment", %{proj: proj} do
+    pr = %BorsNG.GitHub.Pr{
+      number: 1,
+      title: "Test",
+      body: "Mess",
+      state: :open,
+      base_ref: "master",
+      head_sha: "00000001",
+      head_ref: "update",
+      base_repo_id: 13,
+      head_repo_id: 13,
+      user: %{id: 2, login: "pr_author"}
+    }
+
+    toml = ~s"""
+    status = ["ci"]
+    [delegation]
+    default_expiry_sec = #{24 * 60 * 60}
+    invalidate_on_paths = ["Cargo.toml", ".github/**"]
+    """
+
+    GitHub.ServerMock.put_state(%{
+      {{:installation, 91}, 14} => %{
+        branches: %{},
+        comments: %{1 => ["bors delegate+"]},
+        statuses: %{},
+        files: %{"master" => %{"bors.toml" => toml}},
+        pulls: %{1 => pr}
+      }
+    })
+
+    {:ok, user} =
+      Repo.insert(%BorsNG.Database.User{user_xref: 1, is_admin: true, login: "owner"})
+
+    {:ok, _} =
+      Repo.insert(%BorsNG.Database.Patch{
+        project_id: proj.id,
+        pr_xref: 1,
+        commit: "headsha123",
+        into_branch: "master"
+      })
+
+    Repo.insert(%BorsNG.Database.LinkUserProject{user_id: user.id, project_id: proj.id})
+
+    Command.run(%Command{
+      project: proj,
+      commenter: user,
+      comment: "bors delegate+",
+      pr_xref: 1
+    })
+
+    state = GitHub.ServerMock.get_state()
+    comments = get_in(state, [{{:installation, 91}, 14}, :comments, 1])
+
+    assert Enum.any?(comments, fn c ->
+             String.contains?(c, "revoke this delegation") and
+               String.contains?(c, "`Cargo.toml`") and
+               String.contains?(c, "`.github/**`")
+           end)
+  end
+
+  test "delegate+ omits the paths note when invalidate_on_paths is empty", %{proj: proj} do
+    pr = %BorsNG.GitHub.Pr{
+      number: 1,
+      title: "Test",
+      body: "Mess",
+      state: :open,
+      base_ref: "master",
+      head_sha: "00000001",
+      head_ref: "update",
+      base_repo_id: 13,
+      head_repo_id: 13,
+      user: %{id: 2, login: "pr_author"}
+    }
+
+    GitHub.ServerMock.put_state(%{
+      {{:installation, 91}, 14} => %{
+        branches: %{},
+        comments: %{1 => ["bors delegate+"]},
+        statuses: %{},
+        files: %{"master" => %{"bors.toml" => delegation_toml()}},
+        pulls: %{1 => pr}
+      }
+    })
+
+    {:ok, user} =
+      Repo.insert(%BorsNG.Database.User{user_xref: 1, is_admin: true, login: "owner"})
+
+    {:ok, _} =
+      Repo.insert(%BorsNG.Database.Patch{
+        project_id: proj.id,
+        pr_xref: 1,
+        commit: "headsha123",
+        into_branch: "master"
+      })
+
+    Repo.insert(%BorsNG.Database.LinkUserProject{user_id: user.id, project_id: proj.id})
+
+    Command.run(%Command{
+      project: proj,
+      commenter: user,
+      comment: "bors delegate+",
+      pr_xref: 1
+    })
+
+    state = GitHub.ServerMock.get_state()
+    comments = get_in(state, [{{:installation, 91}, 14}, :comments, 1])
+
+    refute Enum.any?(comments, &String.contains?(&1, "revoke this delegation"))
+  end
+
   test "re-delegating the same user replaces expires_at", %{proj: proj} do
     pr = %BorsNG.GitHub.Pr{
       number: 1,

--- a/test/worker/delegation_invalidator_test.exs
+++ b/test/worker/delegation_invalidator_test.exs
@@ -271,6 +271,43 @@ defmodule BorsNG.Worker.DelegationInvalidatorTest do
       refute Enum.any?(comments, &String.contains?(&1, "`Cargo.toml`"))
     end
 
+    test "does not repeat the same warning across tries", %{patch: patch} do
+      put_lint_mock(%{"Cargo.toml" => "_"})
+
+      DelegationInvalidator.lint_for_patch(patch.id)
+      DelegationInvalidator.lint_for_patch(patch.id)
+
+      comments =
+        GitHub.ServerMock.get_state() |> get_in([{{:installation, 93}, 23}, :comments, 9])
+
+      assert Enum.count(comments, &String.contains?(&1, "match no files")) == 1
+    end
+
+    test "warns afresh when the set of unmatched patterns changes", %{patch: patch} do
+      # First try: Cargo.toml exists, so only Gemfile is unmatched.
+      put_lint_mock(%{"Cargo.toml" => "_"})
+      DelegationInvalidator.lint_for_patch(patch.id)
+
+      carried =
+        GitHub.ServerMock.get_state() |> get_in([{{:installation, 93}, 23}, :comments, 9])
+
+      # Second try: Cargo.toml has since been deleted, so the unmatched set is
+      # now {Cargo.toml, Gemfile} — a different message. Carry the first
+      # warning forward to prove dedup keys on the exact body, not on substring.
+      put_lint_mock(%{}, carried)
+      DelegationInvalidator.lint_for_patch(patch.id)
+
+      comments =
+        GitHub.ServerMock.get_state() |> get_in([{{:installation, 93}, 23}, :comments, 9])
+
+      assert Enum.count(comments, &String.contains?(&1, "match no files")) == 2
+
+      assert Enum.any?(
+               comments,
+               &(String.contains?(&1, "`Cargo.toml`") and String.contains?(&1, "`Gemfile`"))
+             )
+    end
+
     test "stays silent when every pattern matches", %{patch: patch} do
       put_lint_mock(%{"Cargo.toml" => "_", "Gemfile" => "_"})
 

--- a/test/worker/delegation_invalidator_test.exs
+++ b/test/worker/delegation_invalidator_test.exs
@@ -39,25 +39,27 @@ defmodule BorsNG.Worker.DelegationInvalidatorTest do
     {:ok, proj: proj, user: user, patch: patch}
   end
 
-  defp put_mock(compare_map, comments \\ []) do
+  @default_toml ~s"""
+  status = ["ci"]
+  [delegation]
+  invalidate_on_paths = ["Cargo.toml", ".github/**"]
+  """
+
+  # opts:
+  #   :pr_files — the PR's net file list (pr_diff, fetched via get_pr_files)
+  #   :delta    — compare map, {delegated_at_commit, head} => [filenames]
+  #   :comments — pre-existing PR comments
+  #   :toml     — bors.toml body (defaults to a deny-list of Cargo.toml/.github)
+  defp put_mock(opts) do
     GitHub.ServerMock.put_state(%{
       {{:installation, 93}, 23} => %{
-        branches: %{
-          # bors.toml stored under the "main" base ref
-          "main" => "base_tip"
-        },
-        comments: %{9 => comments},
+        # bors.toml stored under the "main" base ref
+        branches: %{"main" => "base_tip"},
+        comments: %{9 => Keyword.get(opts, :comments, [])},
         statuses: %{},
-        files: %{
-          "main" => %{
-            "bors.toml" => ~s"""
-            status = ["ci"]
-            [delegation]
-            invalidate_on_paths = ["Cargo.toml", ".github/**"]
-            """
-          }
-        },
-        compare: compare_map
+        files: %{"main" => %{"bors.toml" => Keyword.get(opts, :toml, @default_toml)}},
+        pr_files: %{9 => Keyword.get(opts, :pr_files, [])},
+        compare: Keyword.get(opts, :delta, %{})
       }
     })
   end
@@ -73,12 +75,12 @@ defmodule BorsNG.Worker.DelegationInvalidatorTest do
   end
 
   test "invalidates when a sensitive path is newly touched", %{user: user, patch: patch} do
-    put_mock(%{
-      # 3-dot diff: PR's author content vs base = ["Cargo.toml", "src/lib.rs"]
-      {"main", "new_head_sha"} => ["Cargo.toml", "src/lib.rs"],
+    put_mock(
+      # PR's author content vs base = ["Cargo.toml", "src/lib.rs"]
+      pr_files: ["Cargo.toml", "src/lib.rs"],
       # changes between delegation and new head also touch Cargo.toml
-      {"old_head", "new_head_sha"} => ["Cargo.toml"]
-    })
+      delta: %{{"old_head", "new_head_sha"} => ["Cargo.toml"]}
+    )
 
     delegate!(user, patch, "old_head")
 
@@ -94,12 +96,12 @@ defmodule BorsNG.Worker.DelegationInvalidatorTest do
     user: user,
     patch: patch
   } do
-    put_mock(%{
+    put_mock(
       # Author's PR content doesn't include Cargo.toml
-      {"main", "new_head_sha"} => ["src/lib.rs"],
+      pr_files: ["src/lib.rs"],
       # delta DOES include Cargo.toml because base-merge brought it in
-      {"old_head", "new_head_sha"} => ["Cargo.toml", "src/lib.rs"]
-    })
+      delta: %{{"old_head", "new_head_sha"} => ["Cargo.toml", "src/lib.rs"]}
+    )
 
     delegate!(user, patch, "old_head")
 
@@ -115,10 +117,10 @@ defmodule BorsNG.Worker.DelegationInvalidatorTest do
     user: user,
     patch: patch
   } do
-    put_mock(%{
-      {"main", "new_head_sha"} => ["Cargo.toml"],
-      {"old_head", "new_head_sha"} => ["Cargo.toml"]
-    })
+    put_mock(
+      pr_files: ["Cargo.toml"],
+      delta: %{{"old_head", "new_head_sha"} => ["Cargo.toml"]}
+    )
 
     # bypass Permission.delegate to insert a row without delegated_at_commit
     Repo.insert!(%UserPatchDelegation{user_id: user.id, patch_id: patch.id, expires_at: nil})
@@ -129,10 +131,10 @@ defmodule BorsNG.Worker.DelegationInvalidatorTest do
   end
 
   test "leaves delegations alone when no path matches", %{user: user, patch: patch} do
-    put_mock(%{
-      {"main", "new_head_sha"} => ["src/lib.rs", "README.md"],
-      {"old_head", "new_head_sha"} => ["src/lib.rs"]
-    })
+    put_mock(
+      pr_files: ["src/lib.rs", "README.md"],
+      delta: %{{"old_head", "new_head_sha"} => ["src/lib.rs"]}
+    )
 
     delegate!(user, patch, "old_head")
 
@@ -142,10 +144,10 @@ defmodule BorsNG.Worker.DelegationInvalidatorTest do
   end
 
   test "matches glob patterns under a directory", %{user: user, patch: patch} do
-    put_mock(%{
-      {"main", "new_head_sha"} => [".github/workflows/ci.yml"],
-      {"old_head", "new_head_sha"} => [".github/workflows/ci.yml"]
-    })
+    put_mock(
+      pr_files: [".github/workflows/ci.yml"],
+      delta: %{{"old_head", "new_head_sha"} => [".github/workflows/ci.yml"]}
+    )
 
     delegate!(user, patch, "old_head")
 
@@ -156,11 +158,13 @@ defmodule BorsNG.Worker.DelegationInvalidatorTest do
 
   test "combines revocations into a single comment when multiple delegations match",
        %{user: user, patch: patch} do
-    put_mock(%{
-      {"main", "new_head_sha"} => ["Cargo.toml", ".github/workflows/ci.yml"],
-      {"old_head_a", "new_head_sha"} => ["Cargo.toml"],
-      {"old_head_b", "new_head_sha"} => [".github/workflows/ci.yml"]
-    })
+    put_mock(
+      pr_files: ["Cargo.toml", ".github/workflows/ci.yml"],
+      delta: %{
+        {"old_head_a", "new_head_sha"} => ["Cargo.toml"],
+        {"old_head_b", "new_head_sha"} => [".github/workflows/ci.yml"]
+      }
+    )
 
     bob = Repo.insert!(%User{user_xref: 52, login: "bob"})
 
@@ -181,17 +185,121 @@ defmodule BorsNG.Worker.DelegationInvalidatorTest do
   end
 
   test "no-op when bors.toml has no delegation paths configured", %{user: user, patch: patch} do
-    GitHub.ServerMock.put_state(%{
-      {{:installation, 93}, 23} => %{
-        branches: %{"main" => "base_tip"},
-        comments: %{9 => []},
-        statuses: %{},
-        files: %{"main" => %{"bors.toml" => ~s/status = ["ci"]/}},
-        compare: %{}
-      }
-    })
+    put_mock(toml: ~s/status = ["ci"]/)
 
     delegate!(user, patch, "old_head")
+
+    DelegationInvalidator.invalidate_for_patch(patch.id)
+
+    assert [_] = Repo.all(UserPatchDelegation)
+  end
+
+  @restrict_toml ~s"""
+  status = ["ci"]
+  [delegation]
+  restrict_to_paths = ["src/**"]
+  """
+
+  test "revokes when an authored path is outside restrict_to_paths", %{user: user, patch: patch} do
+    put_mock(
+      toml: @restrict_toml,
+      pr_files: ["src/lib.rs", "docs/readme.md"],
+      delta: %{{"old_head", "new_head_sha"} => ["docs/readme.md"]}
+    )
+
+    delegate!(user, patch, "old_head")
+
+    DelegationInvalidator.invalidate_for_patch(patch.id)
+
+    assert [] == Repo.all(UserPatchDelegation)
+    comments = GitHub.ServerMock.get_state() |> get_in([{{:installation, 93}, 23}, :comments, 9])
+    assert Enum.any?(comments, &String.contains?(&1, "outside the paths this delegation covers"))
+    assert Enum.any?(comments, &String.contains?(&1, "docs/readme.md"))
+  end
+
+  test "leaves delegation alone when authored paths stay within restrict_to_paths", %{
+    user: user,
+    patch: patch
+  } do
+    put_mock(
+      toml: @restrict_toml,
+      pr_files: ["src/lib.rs", "src/util.rs"],
+      delta: %{{"old_head", "new_head_sha"} => ["src/util.rs"]}
+    )
+
+    delegate!(user, patch, "old_head")
+
+    DelegationInvalidator.invalidate_for_patch(patch.id)
+
+    assert [_] = Repo.all(UserPatchDelegation)
+  end
+
+  test "deny-list overrides allow-list for a path inside the scope", %{user: user, patch: patch} do
+    put_mock(
+      toml: ~s"""
+      status = ["ci"]
+      [delegation]
+      restrict_to_paths = ["src/**"]
+      invalidate_on_paths = ["src/crypto.rs"]
+      """,
+      pr_files: ["src/crypto.rs"],
+      delta: %{{"old_head", "new_head_sha"} => ["src/crypto.rs"]}
+    )
+
+    delegate!(user, patch, "old_head")
+
+    DelegationInvalidator.invalidate_for_patch(patch.id)
+
+    assert [] == Repo.all(UserPatchDelegation)
+    comments = GitHub.ServerMock.get_state() |> get_in([{{:installation, 93}, 23}, :comments, 9])
+    assert Enum.any?(comments, &String.contains?(&1, "invalidate_on_paths"))
+    assert Enum.any?(comments, &String.contains?(&1, "src/crypto.rs"))
+  end
+
+  test "revokes (too large) when the delta exceeds the compare cap", %{user: user, patch: patch} do
+    put_mock(
+      pr_files: ["src/lib.rs"],
+      delta: %{{"old_head", "new_head_sha"} => Enum.map(1..300, &"f#{&1}.rs")}
+    )
+
+    delegate!(user, patch, "old_head")
+
+    DelegationInvalidator.invalidate_for_patch(patch.id)
+
+    assert [] == Repo.all(UserPatchDelegation)
+    comments = GitHub.ServerMock.get_state() |> get_in([{{:installation, 93}, 23}, :comments, 9])
+    assert Enum.any?(comments, &String.contains?(&1, "too many files"))
+  end
+
+  test "falls back to delta-only when pr_diff is truncated, over-revoking", %{
+    user: user,
+    patch: patch
+  } do
+    # Cargo.toml is in the delta but NOT in pr_files; with a complete filter it
+    # would be treated as base-merge noise and ignored (see the base-merge
+    # test). Truncating pr_files (>= 3000 files) drops the filter, so the
+    # delta-only fallback flags it instead.
+    put_mock(
+      pr_files: Enum.map(1..3000, &"f#{&1}.rs"),
+      delta: %{{"old_head", "new_head_sha"} => ["Cargo.toml"]}
+    )
+
+    delegate!(user, patch, "old_head")
+
+    DelegationInvalidator.invalidate_for_patch(patch.id)
+
+    assert [] == Repo.all(UserPatchDelegation)
+  end
+
+  test "leaves delegation alone when nothing changed since delegation", %{
+    user: user,
+    patch: patch
+  } do
+    # delegated_at_commit == current head, so the delta compares a commit to
+    # itself; the mock has no entry for it and returns an empty list.
+    put_mock(pr_files: ["Cargo.toml"])
+
+    delegate!(user, patch, "new_head_sha")
 
     DelegationInvalidator.invalidate_for_patch(patch.id)
 

--- a/test/worker/delegation_invalidator_test.exs
+++ b/test/worker/delegation_invalidator_test.exs
@@ -60,7 +60,8 @@ defmodule BorsNG.Worker.DelegationInvalidatorTest do
         statuses: %{},
         files: %{"main" => %{"bors.toml" => Keyword.get(opts, :toml, @default_toml)}},
         pr_files: %{9 => Keyword.get(opts, :pr_files, [])},
-        compare: Keyword.get(opts, :delta, %{})
+        compare: Keyword.get(opts, :delta, %{}),
+        compare_error: Keyword.get(opts, :compare_error, false)
       }
     })
   end
@@ -307,6 +308,24 @@ defmodule BorsNG.Worker.DelegationInvalidatorTest do
     assert [_] = Repo.all(UserPatchDelegation)
   end
 
+  test "push path keeps the delegation when the delta cannot be read (fails open)", %{
+    user: user,
+    patch: patch
+  } do
+    put_mock(compare_error: true)
+    delegate!(user, patch, "old_head")
+
+    DelegationInvalidator.invalidate_for_patch(patch.id)
+
+    # Unlike the merge-time gate, the push path fails open: it can't prove the
+    # change is bad, so it keeps the delegation and posts no revoke. The
+    # merge-time gate is the fail-closed backstop.
+    assert [_] = Repo.all(UserPatchDelegation)
+
+    comments = GitHub.ServerMock.get_state() |> get_in([{{:installation, 93}, 23}, :comments, 9])
+    refute Enum.any?(comments, &String.contains?(&1, "revoked"))
+  end
+
   describe "verify_for_merge/2" do
     test "denies and revokes when a sensitive path changed since delegation", %{
       user: user,
@@ -361,6 +380,24 @@ defmodule BorsNG.Worker.DelegationInvalidatorTest do
       )
 
       assert :ok == DelegationInvalidator.verify_for_merge(patch, user)
+    end
+
+    test "denies without revoking when the delta cannot be read (fails closed)", %{
+      user: user,
+      patch: patch
+    } do
+      put_mock(compare_error: true)
+      delegate!(user, patch, "old_head")
+
+      assert :deny == DelegationInvalidator.verify_for_merge(patch, user)
+      # Fail closed, but do NOT revoke: an unreadable delta isn't proof the
+      # change is bad. A later `bors r+` re-runs the gate.
+      assert [_] = Repo.all(UserPatchDelegation)
+
+      comments =
+        GitHub.ServerMock.get_state() |> get_in([{{:installation, 93}, 23}, :comments, 9])
+
+      assert Enum.any?(comments, &String.contains?(&1, "Couldn't approve via delegation"))
     end
   end
 

--- a/test/worker/delegation_invalidator_test.exs
+++ b/test/worker/delegation_invalidator_test.exs
@@ -3,6 +3,7 @@ defmodule BorsNG.Worker.DelegationInvalidatorTest do
 
   alias BorsNG.Database.Context.Permission
   alias BorsNG.Database.Installation
+  alias BorsNG.Database.LinkUserProject
   alias BorsNG.Database.Patch
   alias BorsNG.Database.Project
   alias BorsNG.Database.Repo
@@ -304,6 +305,63 @@ defmodule BorsNG.Worker.DelegationInvalidatorTest do
     DelegationInvalidator.invalidate_for_patch(patch.id)
 
     assert [_] = Repo.all(UserPatchDelegation)
+  end
+
+  describe "verify_for_merge/2" do
+    test "denies and revokes when a sensitive path changed since delegation", %{
+      user: user,
+      patch: patch
+    } do
+      put_mock(
+        pr_files: ["Cargo.toml", "src/lib.rs"],
+        delta: %{{"old_head", "new_head_sha"} => ["Cargo.toml"]}
+      )
+
+      delegate!(user, patch, "old_head")
+
+      assert :deny == DelegationInvalidator.verify_for_merge(patch, user)
+      assert [] == Repo.all(UserPatchDelegation)
+
+      comments =
+        GitHub.ServerMock.get_state() |> get_in([{{:installation, 93}, 23}, :comments, 9])
+
+      assert Enum.any?(comments, &String.contains?(&1, "revoked"))
+      assert Enum.any?(comments, &String.contains?(&1, "Cargo.toml"))
+    end
+
+    test "allows when nothing sensitive changed since delegation", %{user: user, patch: patch} do
+      put_mock(
+        pr_files: ["src/lib.rs"],
+        delta: %{{"old_head", "new_head_sha"} => ["src/lib.rs"]}
+      )
+
+      delegate!(user, patch, "old_head")
+
+      assert :ok == DelegationInvalidator.verify_for_merge(patch, user)
+      assert [_] = Repo.all(UserPatchDelegation)
+    end
+
+    test "does not block or revoke a project reviewer", %{user: user, patch: patch, proj: proj} do
+      put_mock(
+        pr_files: ["Cargo.toml"],
+        delta: %{{"old_head", "new_head_sha"} => ["Cargo.toml"]}
+      )
+
+      Repo.insert!(%LinkUserProject{user_id: user.id, project_id: proj.id})
+      delegate!(user, patch, "old_head")
+
+      assert :ok == DelegationInvalidator.verify_for_merge(patch, user)
+      assert [_] = Repo.all(UserPatchDelegation)
+    end
+
+    test "allows when the user has no active delegation", %{user: user, patch: patch} do
+      put_mock(
+        pr_files: ["Cargo.toml"],
+        delta: %{{"old_head", "new_head_sha"} => ["Cargo.toml"]}
+      )
+
+      assert :ok == DelegationInvalidator.verify_for_merge(patch, user)
+    end
   end
 
   describe "matches_any?/2" do

--- a/test/worker/delegation_invalidator_test.exs
+++ b/test/worker/delegation_invalidator_test.exs
@@ -217,4 +217,87 @@ defmodule BorsNG.Worker.DelegationInvalidatorTest do
       refute DelegationInvalidator.matches_any?("README.md", patterns)
     end
   end
+
+  describe "unmatched_paths/2" do
+    test "returns patterns matching zero tree entries" do
+      tree = ["Cargo.toml", "src/main.rs", ".github/workflows/ci.yml"]
+
+      assert DelegationInvalidator.unmatched_paths(
+               ["Cargo.toml", "Gemfile", ".github/**"],
+               tree
+             ) == ["Gemfile"]
+    end
+
+    test "returns [] when all patterns match" do
+      tree = ["Cargo.toml", ".github/workflows/ci.yml"]
+      assert DelegationInvalidator.unmatched_paths(["Cargo.toml", ".github/**"], tree) == []
+    end
+
+    test "returns all patterns when tree is empty" do
+      assert DelegationInvalidator.unmatched_paths(["Cargo.toml", "Gemfile"], []) ==
+               ["Cargo.toml", "Gemfile"]
+    end
+  end
+
+  describe "lint_for_patch/1" do
+    @lint_toml ~s"""
+    status = ["ci"]
+    [delegation]
+    invalidate_on_paths = ["Cargo.toml", "Gemfile"]
+    """
+
+    defp put_lint_mock(extra_files, comments \\ []) do
+      GitHub.ServerMock.put_state(%{
+        {{:installation, 93}, 23} => %{
+          branches: %{"main" => "base_tip"},
+          comments: %{9 => comments},
+          statuses: %{},
+          files: %{"main" => Map.merge(%{"bors.toml" => @lint_toml}, extra_files)}
+        }
+      })
+    end
+
+    test "posts a warning when a pattern matches no files", %{patch: patch} do
+      # Tree has Cargo.toml but no Gemfile, so Gemfile is unmatched
+      put_lint_mock(%{"Cargo.toml" => "_"})
+
+      DelegationInvalidator.lint_for_patch(patch.id)
+
+      comments =
+        GitHub.ServerMock.get_state() |> get_in([{{:installation, 93}, 23}, :comments, 9])
+
+      assert Enum.any?(comments, &String.contains?(&1, "match no files"))
+      assert Enum.any?(comments, &String.contains?(&1, "`Gemfile`"))
+      refute Enum.any?(comments, &String.contains?(&1, "`Cargo.toml`"))
+    end
+
+    test "stays silent when every pattern matches", %{patch: patch} do
+      put_lint_mock(%{"Cargo.toml" => "_", "Gemfile" => "_"})
+
+      DelegationInvalidator.lint_for_patch(patch.id)
+
+      comments =
+        GitHub.ServerMock.get_state() |> get_in([{{:installation, 93}, 23}, :comments, 9])
+
+      assert comments == []
+    end
+
+    test "stays silent when invalidate_on_paths is empty", %{patch: patch} do
+      GitHub.ServerMock.put_state(%{
+        {{:installation, 93}, 23} => %{
+          branches: %{"main" => "base_tip"},
+          comments: %{9 => []},
+          statuses: %{},
+          files: %{"main" => %{"bors.toml" => ~s(status = ["ci"])}}
+        }
+      })
+
+      DelegationInvalidator.lint_for_patch(patch.id)
+
+      comments =
+        GitHub.ServerMock.get_state() |> get_in([{{:installation, 93}, 23}, :comments, 9])
+
+      assert comments == []
+    end
+  end
 end

--- a/test/worker/delegation_invalidator_test.exs
+++ b/test/worker/delegation_invalidator_test.exs
@@ -154,6 +154,32 @@ defmodule BorsNG.Worker.DelegationInvalidatorTest do
     assert [] == Repo.all(UserPatchDelegation)
   end
 
+  test "combines revocations into a single comment when multiple delegations match",
+       %{user: user, patch: patch} do
+    put_mock(%{
+      {"main", "new_head_sha"} => ["Cargo.toml", ".github/workflows/ci.yml"],
+      {"old_head_a", "new_head_sha"} => ["Cargo.toml"],
+      {"old_head_b", "new_head_sha"} => [".github/workflows/ci.yml"]
+    })
+
+    bob = Repo.insert!(%User{user_xref: 52, login: "bob"})
+
+    delegate!(user, patch, "old_head_a")
+    delegate!(bob, patch, "old_head_b")
+
+    DelegationInvalidator.invalidate_for_patch(patch.id)
+
+    assert [] == Repo.all(UserPatchDelegation)
+
+    comments = GitHub.ServerMock.get_state() |> get_in([{{:installation, 93}, 23}, :comments, 9])
+    assert length(comments) == 1
+    [combined] = comments
+    assert String.contains?(combined, "alice")
+    assert String.contains?(combined, "bob")
+    assert String.contains?(combined, "Cargo.toml")
+    assert String.contains?(combined, ".github/workflows/ci.yml")
+  end
+
   test "no-op when bors.toml has no delegation paths configured", %{user: user, patch: patch} do
     GitHub.ServerMock.put_state(%{
       {{:installation, 93}, 23} => %{

--- a/test/worker/delegation_invalidator_test.exs
+++ b/test/worker/delegation_invalidator_test.exs
@@ -1,0 +1,194 @@
+defmodule BorsNG.Worker.DelegationInvalidatorTest do
+  use ExUnit.Case
+
+  alias BorsNG.Database.Context.Permission
+  alias BorsNG.Database.Installation
+  alias BorsNG.Database.Patch
+  alias BorsNG.Database.Project
+  alias BorsNG.Database.Repo
+  alias BorsNG.Database.User
+  alias BorsNG.Database.UserPatchDelegation
+  alias BorsNG.GitHub
+  alias BorsNG.Worker.DelegationInvalidator
+
+  setup do
+    :ok = Ecto.Adapters.SQL.Sandbox.checkout(Repo)
+    Ecto.Adapters.SQL.Sandbox.mode(Repo, {:shared, self()})
+
+    inst = Repo.insert!(%Installation{installation_xref: 93})
+
+    proj =
+      Repo.insert!(%Project{
+        installation_id: inst.id,
+        repo_xref: 23,
+        staging_branch: "staging",
+        name: "example/inval"
+      })
+
+    user = Repo.insert!(%User{user_xref: 51, login: "alice"})
+
+    patch =
+      Repo.insert!(%Patch{
+        project_id: proj.id,
+        pr_xref: 9,
+        commit: "new_head_sha",
+        into_branch: "main",
+        open: true
+      })
+
+    {:ok, proj: proj, user: user, patch: patch}
+  end
+
+  defp put_mock(compare_map, comments \\ []) do
+    GitHub.ServerMock.put_state(%{
+      {{:installation, 93}, 23} => %{
+        branches: %{
+          # bors.toml stored under the "main" base ref
+          "main" => "base_tip"
+        },
+        comments: %{9 => comments},
+        statuses: %{},
+        files: %{
+          "main" => %{
+            "bors.toml" => ~s"""
+            status = ["ci"]
+            [delegation]
+            invalidate_on_paths = ["Cargo.toml", ".github/**"]
+            """
+          }
+        },
+        compare: compare_map
+      }
+    })
+  end
+
+  defp delegate!(user, patch, delegated_at_commit) do
+    Permission.delegate(user, patch,
+      expires_at:
+        NaiveDateTime.utc_now()
+        |> NaiveDateTime.add(86_400, :second)
+        |> NaiveDateTime.truncate(:second),
+      delegated_at_commit: delegated_at_commit
+    )
+  end
+
+  test "invalidates when a sensitive path is newly touched", %{user: user, patch: patch} do
+    put_mock(%{
+      # 3-dot diff: PR's author content vs base = ["Cargo.toml", "src/lib.rs"]
+      {"main", "new_head_sha"} => ["Cargo.toml", "src/lib.rs"],
+      # changes between delegation and new head also touch Cargo.toml
+      {"old_head", "new_head_sha"} => ["Cargo.toml"]
+    })
+
+    delegate!(user, patch, "old_head")
+
+    DelegationInvalidator.invalidate_for_patch(patch.id)
+
+    assert [] == Repo.all(UserPatchDelegation)
+    comments = GitHub.ServerMock.get_state() |> get_in([{{:installation, 93}, 23}, :comments, 9])
+    assert Enum.any?(comments, &String.contains?(&1, "revoked"))
+    assert Enum.any?(comments, &String.contains?(&1, "Cargo.toml"))
+  end
+
+  test "does NOT invalidate on a base-merge bringing sensitive content from base", %{
+    user: user,
+    patch: patch
+  } do
+    put_mock(%{
+      # Author's PR content doesn't include Cargo.toml
+      {"main", "new_head_sha"} => ["src/lib.rs"],
+      # delta DOES include Cargo.toml because base-merge brought it in
+      {"old_head", "new_head_sha"} => ["Cargo.toml", "src/lib.rs"]
+    })
+
+    delegate!(user, patch, "old_head")
+
+    DelegationInvalidator.invalidate_for_patch(patch.id)
+
+    assert [d] = Repo.all(UserPatchDelegation)
+    assert d.user_id == user.id
+    comments = GitHub.ServerMock.get_state() |> get_in([{{:installation, 93}, 23}, :comments, 9])
+    assert comments == []
+  end
+
+  test "ignores delegations without delegated_at_commit (legacy rows)", %{
+    user: user,
+    patch: patch
+  } do
+    put_mock(%{
+      {"main", "new_head_sha"} => ["Cargo.toml"],
+      {"old_head", "new_head_sha"} => ["Cargo.toml"]
+    })
+
+    # bypass Permission.delegate to insert a row without delegated_at_commit
+    Repo.insert!(%UserPatchDelegation{user_id: user.id, patch_id: patch.id, expires_at: nil})
+
+    DelegationInvalidator.invalidate_for_patch(patch.id)
+
+    assert [_] = Repo.all(UserPatchDelegation)
+  end
+
+  test "leaves delegations alone when no path matches", %{user: user, patch: patch} do
+    put_mock(%{
+      {"main", "new_head_sha"} => ["src/lib.rs", "README.md"],
+      {"old_head", "new_head_sha"} => ["src/lib.rs"]
+    })
+
+    delegate!(user, patch, "old_head")
+
+    DelegationInvalidator.invalidate_for_patch(patch.id)
+
+    assert [_] = Repo.all(UserPatchDelegation)
+  end
+
+  test "matches glob patterns under a directory", %{user: user, patch: patch} do
+    put_mock(%{
+      {"main", "new_head_sha"} => [".github/workflows/ci.yml"],
+      {"old_head", "new_head_sha"} => [".github/workflows/ci.yml"]
+    })
+
+    delegate!(user, patch, "old_head")
+
+    DelegationInvalidator.invalidate_for_patch(patch.id)
+
+    assert [] == Repo.all(UserPatchDelegation)
+  end
+
+  test "no-op when bors.toml has no delegation paths configured", %{user: user, patch: patch} do
+    GitHub.ServerMock.put_state(%{
+      {{:installation, 93}, 23} => %{
+        branches: %{"main" => "base_tip"},
+        comments: %{9 => []},
+        statuses: %{},
+        files: %{"main" => %{"bors.toml" => ~s/status = ["ci"]/}},
+        compare: %{}
+      }
+    })
+
+    delegate!(user, patch, "old_head")
+
+    DelegationInvalidator.invalidate_for_patch(patch.id)
+
+    assert [_] = Repo.all(UserPatchDelegation)
+  end
+
+  describe "matches_any?/2" do
+    test "literal path match" do
+      assert DelegationInvalidator.matches_any?("Cargo.toml", ["Cargo.toml"])
+      refute DelegationInvalidator.matches_any?("Cargo.lock", ["Cargo.toml"])
+    end
+
+    test "directory glob" do
+      assert DelegationInvalidator.matches_any?(".github/workflows/ci.yml", [".github/**"])
+      assert DelegationInvalidator.matches_any?(".github/dependabot.yml", [".github/**"])
+      refute DelegationInvalidator.matches_any?("src/main.rs", [".github/**"])
+    end
+
+    test "any of multiple patterns matches" do
+      patterns = ["Cargo.toml", ".github/**"]
+      assert DelegationInvalidator.matches_any?("Cargo.toml", patterns)
+      assert DelegationInvalidator.matches_any?(".github/foo.yml", patterns)
+      refute DelegationInvalidator.matches_any?("README.md", patterns)
+    end
+  end
+end

--- a/test/worker/delegation_invalidator_test.exs
+++ b/test/worker/delegation_invalidator_test.exs
@@ -485,6 +485,28 @@ defmodule BorsNG.Worker.DelegationInvalidatorTest do
       assert comments == []
     end
 
+    test "stays silent when the base tree is truncated", %{patch: patch} do
+      # Cargo.toml is present and Gemfile is missing, which would normally warn
+      # about Gemfile. But the tree is truncated, so the file set is incomplete
+      # and the lint must skip rather than warn off a partial listing.
+      GitHub.ServerMock.put_state(%{
+        {{:installation, 93}, 23} => %{
+          branches: %{"main" => "base_tip"},
+          comments: %{9 => []},
+          statuses: %{},
+          truncated_trees: ["main"],
+          files: %{"main" => %{"bors.toml" => @lint_toml, "Cargo.toml" => "_"}}
+        }
+      })
+
+      DelegationInvalidator.lint_for_patch(patch.id)
+
+      comments =
+        GitHub.ServerMock.get_state() |> get_in([{{:installation, 93}, 23}, :comments, 9])
+
+      assert comments == []
+    end
+
     test "stays silent when invalidate_on_paths is empty", %{patch: patch} do
       GitHub.ServerMock.put_state(%{
         {{:installation, 93}, 23} => %{


### PR DESCRIPTION
Adds an optional `[delegation]` section to `bors.toml` that lets a project bound what an approval
delegation (`bors d=...`) covers, and revokes the delegation automatically when new author work
strays outside that boundary.

Two keys control the scope:
- `restrict_to_paths`: an allow-list; the delegation covers only changes within these paths, and
touching anything else revokes it.
- `invalidate_on_paths`: a deny-list of sensitive paths that always revoke, even when they fall
inside `restrict_to_paths`.

The invalidator isolates new author work since the delegation was issued by intersecting two
GitHub compares (delegation-commit→head and base→head), so unrelated upstream churn doesn't trip
it. Decisions are deliberately asymmetric: ambiguous cases prefer over-revoking, since a wrongly
revoked delegation just costs a re-issue while a wrongly retained one can merge a sensitive change
unreviewed. GitHub's file-count caps are treated as truncation and resolved in the revoke
direction.

A fail-closed gate at merge time (`bors r+`) re-checks the boundary so a delegation can't slip
through if the PR grew after the last sync. get_pr_files now paginates up to GitHub's 3000-file
cap. Delegation-success comments echo the active scope, and both delegation lists carry a standing
note explaining the policy.

Design and rationale are documented in `DELEGATION_INVALIDATION.md`.

Prepared with Claude code