### PR TITLE
fix: clarify and correct bors PR comments

### DIFF
--- a/lib/web/command.ex
+++ b/lib/web/command.ex
@@ -560,7 +560,7 @@ defmodule BorsNG.Command do
       """
       :lock: Permission denied
 
-      Existing reviewers: [click here to make #{login} a reviewer](#{url})
+      An existing reviewer can [click here to make #{login} a reviewer](#{url}).
       """
     )
   end

--- a/lib/web/controllers/webhook_controller.ex
+++ b/lib/web/controllers/webhook_controller.ex
@@ -373,7 +373,7 @@ defmodule BorsNG.WebhookController do
 
     if had_incomplete_batch do
       batcher = Batcher.Registry.get(project.id)
-      Batcher.cancel(batcher, patch.id)
+      Batcher.cancel(batcher, patch.id, :draft)
     end
 
     if had_incomplete_attempt do
@@ -425,7 +425,7 @@ defmodule BorsNG.WebhookController do
     # Ensure a closed PR is removed from any waiting/running batches and try jobs
     batcher = Batcher.Registry.get(project.id)
     # Batcher.cancel is the same as running bors r-
-    Batcher.cancel(batcher, p.id)
+    Batcher.cancel(batcher, p.id, :closed)
     attemptor = Attemptor.Registry.get(project.id)
     Attemptor.cancel(attemptor, p.id)
     BranchDeleter.delete(p)
@@ -439,7 +439,7 @@ defmodule BorsNG.WebhookController do
 
   def do_webhook_pr(conn, %{action: "synchronize", project: pro, patch: p}) do
     batcher = Batcher.Registry.get(pro.id)
-    Batcher.cancel(batcher, p.id)
+    Batcher.cancel(batcher, p.id, :push)
     attemptor = Attemptor.Registry.get(pro.id)
     Attemptor.cancel(attemptor, p.id)
     commit = conn.body_params["pull_request"]["head"]["sha"]

--- a/lib/worker/attemptor.ex
+++ b/lib/worker/attemptor.ex
@@ -405,7 +405,7 @@ defmodule BorsNG.Worker.Attemptor do
         &(&1.state == :error)
       )
 
-    send_message(repo_conn, patch, {:failed, erred})
+    send_message(repo_conn, patch, {:try_failed, erred})
   end
 
   defp maybe_complete_attempt(:running, _project, _patch, _statuses) do
@@ -429,7 +429,7 @@ defmodule BorsNG.Worker.Attemptor do
   defp timeout_attempt(attempt, project, patch) do
     project
     |> get_repo_conn()
-    |> send_message(patch, {:timeout, :failed})
+    |> send_message(patch, {:timeout, :try})
 
     attempt
     |> Attempt.changeset(%{state: :error})

--- a/lib/worker/batcher.ex
+++ b/lib/worker/batcher.ex
@@ -69,8 +69,8 @@ defmodule BorsNG.Worker.Batcher do
     send(pid, {:poll, :once})
   end
 
-  def cancel(pid, patch_id) when is_integer(patch_id) do
-    GenServer.cast(pid, {:cancel, patch_id})
+  def cancel(pid, patch_id, reason \\ :requested) when is_integer(patch_id) do
+    GenServer.cast(pid, {:cancel, patch_id, reason})
   end
 
   def cancel_all(pid) do
@@ -194,11 +194,16 @@ defmodule BorsNG.Worker.Batcher do
     end
   end
 
-  def do_handle_cast({:cancel, patch_id}, _project_id) do
+  def do_handle_cast({:cancel, patch_id, reason}, _project_id) do
     patch_id
     |> Batch.all_for_patch(:incomplete)
     |> Repo.one()
-    |> cancel_patch(patch_id)
+    |> cancel_patch(patch_id, reason)
+  end
+
+  # Backwards compatibility for any in-flight 2-tuple casts (e.g. across a deploy).
+  def do_handle_cast({:cancel, patch_id}, project_id) do
+    do_handle_cast({:cancel, patch_id, :requested}, project_id)
   end
 
   def do_handle_cast({:cancel_all}, project_id) do
@@ -1069,14 +1074,14 @@ defmodule BorsNG.Worker.Batcher do
     |> send_status(batch, :timeout)
   end
 
-  defp cancel_patch(nil, _), do: :ok
+  defp cancel_patch(nil, _, _), do: :ok
 
-  defp cancel_patch(batch, patch_id) do
-    cancel_patch(batch, patch_id, batch.state)
+  defp cancel_patch(batch, patch_id, reason) do
+    cancel_patch(batch, patch_id, batch.state, reason)
     Project.ping!(batch.project_id)
   end
 
-  defp cancel_patch(batch, patch_id, :running) do
+  defp cancel_patch(batch, patch_id, :running, reason) do
     project = batch.project
 
     patch_links =
@@ -1121,16 +1126,16 @@ defmodule BorsNG.Worker.Batcher do
           &(&1.id != patch_id)
         )
 
-      send_message(repo_conn, canceled_patches, {:canceled, :failed})
+      send_message(repo_conn, canceled_patches, {:canceled, :failed, reason})
       send_message(repo_conn, uncanceled_patches, {:canceled, :retrying})
     else
-      send_message(repo_conn, patches, {:canceled, :failed})
+      send_message(repo_conn, patches, {:canceled, :failed, reason})
     end
 
     send_status(repo_conn, batch, :canceled)
   end
 
-  defp cancel_patch(batch, patch_id, _state) do
+  defp cancel_patch(batch, patch_id, _state, reason) do
     project = batch.project
 
     LinkPatchBatch
@@ -1144,7 +1149,7 @@ defmodule BorsNG.Worker.Batcher do
     patch = Repo.get!(Patch, patch_id)
     repo_conn = get_repo_conn(project)
     send_status(repo_conn, batch.id, [patch], :canceled)
-    send_message(repo_conn, [patch], {:canceled, :failed})
+    send_message(repo_conn, [patch], {:canceled, :failed, reason})
   end
 
   defp patch_preflight(repo_conn, patch) do

--- a/lib/worker/batcher/message.ex
+++ b/lib/worker/batcher/message.ex
@@ -34,7 +34,7 @@ defmodule BorsNG.Worker.Batcher.Message do
   end
 
   def generate_status(:race) do
-    {"Synchronization error!", :error}
+    {"Synchronization error: PR head changed", :error}
   end
 
   def generate_status(:delayed) do
@@ -42,7 +42,7 @@ defmodule BorsNG.Worker.Batcher.Message do
   end
 
   def generate_message(:race) do
-    "Synchronization error!"
+    "Synchronization error: the pull request's head commit changed after it was approved (most likely a new push), so the built batch no longer matches the current code and bors did not merge it. Re-run `bors r+` once the PR is ready."
   end
 
   def generate_message({:preflight, :waiting}) do
@@ -86,7 +86,7 @@ defmodule BorsNG.Worker.Batcher.Message do
   end
 
   def generate_message({:preflight, :ci_skip}) do
-    "Has [ci skip][skip ci][skip netlify], bors build will time out"
+    "This PR's title or body contains the CI-skip marker `[ci skip][skip ci][skip netlify]`, so CI won't run and the bors build would time out. Remove the marker before running bors."
   end
 
   def generate_message(:already_running_review) do
@@ -113,8 +113,30 @@ defmodule BorsNG.Worker.Batcher.Message do
     "This PR was included in a batch that timed out, it will be automatically retried"
   end
 
-  def generate_message({:canceled, :failed}) do
-    "Canceled.\n\nAddress comments or fix if necessary, and then someone with permission can run `bors r+`."
+  # `bors try` is a trial build, not a merge attempt, so its failure/timeout
+  # messages must not suggest `bors r+` (which would queue a merge of code that
+  # just failed). The right next step is to fix and run `bors try` again.
+  def generate_message({:timeout, :try}) do
+    "Timed out.\n\nFix if necessary, and then run `bors try` again."
+  end
+
+  def generate_message({:canceled, :failed, :push}) do
+    "Bors build canceled because the PR branch was pushed to.\n\nThis cancels the in-progress bors run; if the push also touched a delegation-restricted path, any affected delegation is revoked in a separate comment. Address comments or fix if necessary, and then someone with permission can re-run `bors r+` once the PR is ready."
+  end
+
+  # A closed or draft PR has already been told what happened (the PR is closed,
+  # or the draft-mode notice lists what was cleaned up), so an extra "canceled"
+  # comment telling the author to run `bors r+` would be noise or contradictory.
+  def generate_message({:canceled, :failed, :closed}) do
+    nil
+  end
+
+  def generate_message({:canceled, :failed, :draft}) do
+    nil
+  end
+
+  def generate_message({:canceled, :failed, _reason}) do
+    "Bors build canceled.\n\nAddress comments or fix if necessary, and then someone with permission can run `bors r+`."
   end
 
   def generate_message({:canceled, :retrying}) do
@@ -171,6 +193,9 @@ defmodule BorsNG.Worker.Batcher.Message do
         :failed ->
           "Build failed:"
 
+        :try_failed ->
+          "Build failed:"
+
         :retrying ->
           "Build failed (retrying...):"
       end
@@ -183,6 +208,9 @@ defmodule BorsNG.Worker.Batcher.Message do
       :failed ->
         body <>
           "\n\nFix if necessary, and then someone with permission can run `bors r+` or `bors retry`."
+
+      :try_failed ->
+        body <> "\n\nFix if necessary, and then run `bors try` again."
 
       _ ->
         body

--- a/lib/worker/syncer.ex
+++ b/lib/worker/syncer.ex
@@ -139,7 +139,7 @@ defmodule BorsNG.Worker.Syncer do
 
   def do_synchronize!(project_id, {:close, patch}) do
     batcher = Batcher.Registry.get(project_id)
-    Batcher.cancel(batcher, patch.id)
+    Batcher.cancel(batcher, patch.id, :closed)
     attemptor = Attemptor.Registry.get(project_id)
     Attemptor.cancel(attemptor, patch.id)
 

--- a/test/attemptor_test.exs
+++ b/test/attemptor_test.exs
@@ -994,7 +994,7 @@ defmodule BorsNG.Worker.AttemptorTest do
     comments = state[{{:installation, 91}, 14}].comments[1]
 
     assert comments == [
-             "## try\n\nHas [ci skip][skip ci][skip netlify], bors build will time out"
+             "## try\n\nThis PR's title or body contains the CI-skip marker `[ci skip][skip ci][skip netlify]`, so CI won't run and the bors build would time out. Remove the marker before running bors."
            ]
   end
 end

--- a/test/batcher/batcher_test.exs
+++ b/test/batcher/batcher_test.exs
@@ -127,7 +127,7 @@ defmodule BorsNG.Worker.BatcherTest do
                commits: %{},
                comments: %{
                  1 => [
-                   "Canceled.\n\nAddress comments or fix if necessary, and then someone with permission can run `bors r+`."
+                   "Bors build canceled.\n\nAddress comments or fix if necessary, and then someone with permission can run `bors r+`."
                  ],
                  2 => []
                },
@@ -178,7 +178,7 @@ defmodule BorsNG.Worker.BatcherTest do
                commits: %{},
                comments: %{
                  1 => [
-                   "Canceled.\n\nAddress comments or fix if necessary, and then someone with permission can run `bors r+`."
+                   "Bors build canceled.\n\nAddress comments or fix if necessary, and then someone with permission can run `bors r+`."
                  ]
                },
                statuses: %{"N" => %{"bors" => :error}},
@@ -240,7 +240,7 @@ defmodule BorsNG.Worker.BatcherTest do
     }
     |> Repo.insert!()
 
-    Batcher.handle_cast({:cancel, patch.id}, proj.id)
+    Batcher.handle_cast({:cancel, patch.id, :push}, proj.id)
     state = GitHub.ServerMock.get_state()
 
     assert state == %{
@@ -249,7 +249,7 @@ defmodule BorsNG.Worker.BatcherTest do
                commits: %{},
                comments: %{
                  1 => [
-                   "Canceled.\n\nAddress comments or fix if necessary, and then someone with permission can run `bors r+`."
+                   "Bors build canceled because the PR branch was pushed to.\n\nThis cancels the in-progress bors run; if the push also touched a delegation-restricted path, any affected delegation is revoked in a separate comment. Address comments or fix if necessary, and then someone with permission can re-run `bors r+` once the PR is ready."
                  ],
                  2 => [
                    "This PR was included in a batch that was canceled, it will be automatically retried"
@@ -2983,7 +2983,11 @@ defmodule BorsNG.Worker.BatcherTest do
     assert batch.state == :error
 
     state = GitHub.ServerMock.get_state()[{{:installation, 91}, 14}]
-    assert "Synchronization error!" in state.comments[1]
+
+    assert "Synchronization error: the pull request's head commit changed after it was approved (most likely a new push), so the built batch no longer matches the current code and bors did not merge it. Re-run `bors r+` once the PR is ready." in state.comments[
+             1
+           ]
+
     # master never advanced and the PR was never merged — the moved head "O"
     # (which nothing verified) did not reach the target branch.
     assert state.branches["master"] == "ini"
@@ -7192,7 +7196,10 @@ defmodule BorsNG.Worker.BatcherTest do
 
     state = GitHub.ServerMock.get_state()
     comments = state[{{:installation, 91}, 14}].comments[1]
-    assert comments == ["Has [ci skip][skip ci][skip netlify], bors build will time out"]
+
+    assert comments == [
+             "This PR's title or body contains the CI-skip marker `[ci skip][skip ci][skip netlify]`, so CI won't run and the bors build would time out. Remove the marker before running bors."
+           ]
   end
 
   test "full desync detection", %{proj: proj} do
@@ -7285,7 +7292,9 @@ defmodule BorsNG.Worker.BatcherTest do
                  "ini" => %{commit_message: "[ci skip][skip ci][skip netlify]", parents: ["ini"]}
                },
                comments: %{
-                 1 => ["Synchronization error!"]
+                 1 => [
+                   "Synchronization error: the pull request's head commit changed after it was approved (most likely a new push), so the built batch no longer matches the current code and bors did not merge it. Re-run `bors r+` once the PR is ready."
+                 ]
                },
                statuses: %{
                  "N" => %{"bors" => :error}

--- a/test/batcher/message_test.exs
+++ b/test/batcher/message_test.exs
@@ -109,10 +109,23 @@ defmodule BorsNG.Worker.BatcherMessageTest do
 
   test "generate canceled message" do
     expected_message =
-      "Canceled.\n\nAddress comments or fix if necessary, and then someone with permission can run `bors r+`."
+      "Bors build canceled.\n\nAddress comments or fix if necessary, and then someone with permission can run `bors r+`."
 
-    actual_message = Message.generate_message({:canceled, :failed})
+    actual_message = Message.generate_message({:canceled, :failed, :requested})
     assert expected_message == actual_message
+  end
+
+  test "generate canceled message names the push as the reason and defers to the delegation comment" do
+    expected_message =
+      "Bors build canceled because the PR branch was pushed to.\n\nThis cancels the in-progress bors run; if the push also touched a delegation-restricted path, any affected delegation is revoked in a separate comment. Address comments or fix if necessary, and then someone with permission can re-run `bors r+` once the PR is ready."
+
+    actual_message = Message.generate_message({:canceled, :failed, :push})
+    assert expected_message == actual_message
+  end
+
+  test "generate canceled message is suppressed for closed and draft PRs" do
+    assert nil == Message.generate_message({:canceled, :failed, :closed})
+    assert nil == Message.generate_message({:canceled, :failed, :draft})
   end
 
   test "generate canceled/retry message" do
@@ -136,6 +149,22 @@ defmodule BorsNG.Worker.BatcherMessageTest do
       "This PR was included in a batch that timed out, it will be automatically retried"
 
     actual_message = Message.generate_message({:timeout, :retrying})
+    assert expected_message == actual_message
+  end
+
+  test "generate try timeout message suggests `bors try`, not `bors r+`" do
+    expected_message = "Timed out.\n\nFix if necessary, and then run `bors try` again."
+
+    actual_message = Message.generate_message({:timeout, :try})
+    assert expected_message == actual_message
+  end
+
+  test "generate try failure message suggests `bors try`, not `bors r+`" do
+    expected_message =
+      "Build failed:\n  * stat\n\nFix if necessary, and then run `bors try` again."
+
+    example_statuses = [%{url: nil, identifier: "stat"}]
+    actual_message = Message.generate_message({:try_failed, example_statuses})
     assert expected_message == actual_message
   end
 

--- a/test/controllers/webhook_controller_test.exs
+++ b/test/controllers/webhook_controller_test.exs
@@ -492,10 +492,11 @@ defmodule BorsNG.WebhookControllerTest do
     assert comments == []
   end
 
-  test "converting a running PR to draft posts canceled message and draft notice", %{
-    conn: conn,
-    project: proj
-  } do
+  test "converting a running PR to draft posts only the draft notice, not a separate canceled comment",
+       %{
+         conn: conn,
+         project: proj
+       } do
     GitHub.ServerMock.put_state(%{
       {{:installation, 31}, 13} => %{
         branches: %{},
@@ -559,11 +560,11 @@ defmodule BorsNG.WebhookControllerTest do
       |> Map.get(:comments)
       |> Map.get(1)
 
-    assert Enum.any?(
-             comments,
-             &(&1 ==
-                 "Canceled.\n\nAddress comments or fix if necessary, and then someone with permission can run `bors r+`.")
-           )
+    # The draft-mode notice already explains the PR was removed from the merge
+    # queue, so bors must not also post a standalone "Bors build canceled"
+    # comment telling the author to run `bors r+` (which would contradict draft
+    # mode).
+    refute Enum.any?(comments, &String.contains?(&1, "Bors build canceled"))
 
     assert Enum.any?(comments, &String.contains?(&1, "now in draft mode"))
   end


### PR DESCRIPTION
The batch-cancel comment started with a bare "Canceled.", which a reader misread as their delegation being canceled. This makes the cancellation comments reason-aware and cleans up a few other comments along the way.

## Cancellation messages

`Batcher.cancel/3` now threads the trigger through to the message:

- **push** — "Bors build canceled because the PR branch was pushed to", and defers to the separate `DelegationInvalidator` comment for delegation state (a push *can* revoke a delegation when it touches a restricted path, so the message no longer claims otherwise)
- **`bors r-`** — "Bors build canceled." — names its subject
- **closed** — suppressed (the PR is closed)
- **draft** — suppressed; the draft-mode notice already covers it, and "run `bors r+`" would contradict draft mode

## Other comments

- `permission_denied`: "Existing reviewers: [link]" read as a list label; now "An existing reviewer can [link]."
- `bors try` failures reused the merge messages and suggested `bors r+`, which would queue a merge of code that just failed. Added try-only variants that suggest `bors try` instead; merge wording is unchanged.
- ci_skip: the bare `[ci skip][skip ci][skip netlify]` rendered as broken markdown links; wrapped in a code span and explained.
- `:race`: "Synchronization error!" now explains the PR head changed after approval so the batch was not merged, and to re-run `bors r+`.

Full test suite passes; `mix format` clean.

Prepared with Claude code.