### PR TITLE
fix(delegation): don't revoke on base-merge churn that truncates the delta

### DIFF
--- a/DELEGATION_INVALIDATION.md
+++ b/DELEGATION_INVALIDATION.md
@@ -207,17 +207,44 @@ handled separately:
 
 | Case | Meaning | Handling |
 |------|---------|----------|
-| **`delta` truncated** (>300 files changed *after* delegation) | Cannot enumerate the delegate's new work; an unacceptable path might be hidden in the overflow | **Fail safe.** Over-revoke on `synchronize`; deny on `r+`. |
+| **`delta` truncated** (>300 files changed *after* delegation) | The delta may be incomplete, but it is dominated by base-merge noise that the `pr_diff` filter removes; an unacceptable path can only be hidden if it is also **authored** | **Filter first, then conditionally fail safe** (see below). |
 | **`pr_diff` truncated** (>3000 files in the whole PR) | Only the *noise filter* is incomplete; `delta` is still fully known | **Delta-only fallback.** Evaluate `delta` without the intersection. Can only over-revoke (a base-merge file may count as authored), never under-revoke. |
 | **`delta` empty** (no changes since delegation) | Nothing to check | **Short-circuit.** Do not even fetch `pr_diff`; the delegation stands. |
 
-The allow-list makes the truncated-`delta` case fall out naturally rather than
-needing a bolted-on rule. Its normal rule is already "revoke unless every
-authored path is known-acceptable"; overflow paths we cannot see are not
-known-acceptable, so they revoke by the same logic. A deny-list alone needs the
-explicit special case "if truncated, revoke even though no *visible* path
-matched," because a sensitive path could be hiding in the overflow. The
-fail-safe *direction* — uncertainty revokes — is identical for both.
+### The truncated-`delta` rule, refined
+
+A naive "any `delta` truncation → revoke" is wrong, and was the original bug
+(see "Why filtering must precede the truncation check"). The truncated overflow
+is overwhelmingly base-merge files — exactly the noise `pr_diff` strips — so by
+itself it proves nothing. `delta` truncation is only dangerous when it could
+hide the *newness* of an **authored** unacceptable path. So the check is
+filtered, not raw:
+
+1. Intersect the (possibly truncated) `delta` with `pr_diff` and classify the
+   result. Any unacceptable path here revokes with its **specific** reason
+   (sensitive / out-of-scope), truncation or not.
+2. If nothing visible is unacceptable **and** `delta` was truncated, fall back
+   to `:too_large` **only if some authored path (`pr_diff`) is unacceptable at
+   all** — i.e. the truncation could be masking whether that path is new. If
+   every authored path is in scope, the hidden overflow is all base-merge noise
+   and cannot hide an authored violation, so the delegation stands.
+
+When `pr_diff` itself is truncated (`:no_filter`), we cannot bound the authored
+set, so any `delta` truncation conservatively fails safe — the over-revoke
+direction, consistent with the delta-only fallback above.
+
+### Why filtering must precede the truncation check
+
+The decisive case is mathlib4 PR #39106: the author clicked "Update branch",
+pulling in hundreds of master files. The three-dot `delta`
+(`delegated_at_commit...head`) drags in every file master touched since the
+branch point, so it blows past the 300-file cap on a busy base branch *as a
+matter of course*. The original code returned `:too_large` on that raw size
+before ever filtering, revoking a delegation whose authored diff was a single
+in-scope file — defeating the feature in exactly the scenario the `pr_diff`
+filter was built for. The allow-list's normal rule ("revoke unless every
+authored path is known-acceptable") still drives the decision; we just no longer
+let unseen *base-merge* paths, which are never authored, trip it.
 
 ### Why the split, and "un-actionable delegations"
 
@@ -231,10 +258,14 @@ The split avoids this. The decisive test case:
 |---|---|---|
 | `bors r+` | empty `delta` → nothing to check → **approves** ✅ | `pr_diff` truncated → **denied** ❌ |
 
-Under the split policy, a delegation becomes un-actionable **only if the
-delegate's own post-delegation changes exceed ~300 files** — which is within
-their control and arguably *should* demand a fresh human review. A large but
-finished PR stays fully delegatable.
+Under the split policy, a delegation becomes un-actionable only if the
+delegate's own post-delegation changes exceed ~300 files **and** include an
+authored path outside the configured scope (per the refined truncated-`delta`
+rule above). Syncing the base branch — even a busy one that pushes the raw
+`delta` well past 300 — is *not* enough on its own; it is all base-merge noise.
+The remaining un-actionable case is within the delegate's control and arguably
+*should* demand a fresh human review. A large but finished PR stays fully
+delegatable.
 
 ## User-facing messages
 
@@ -303,9 +334,11 @@ issued.
   `delta` includes base-merge content, the missing noise filter may revoke a
   delegation that a complete filter would have spared. This is the accepted
   safe direction.
-- **`delta` is hard-capped at 300 by GitHub** with no pagination escape. A
-  genuinely huge post-delegation push is therefore un-mergeable by a delegate
-  by design.
+- **`delta` is hard-capped at 300 by GitHub** with no pagination escape. This
+  no longer revokes on its own (the filter runs first), but a post-delegation
+  push that both exceeds 300 changed files *and* touches an out-of-scope
+  authored path is un-mergeable by a delegate by design: the truncation hides
+  whether that path is new, so bors fails safe.
 
 See also [bors-ng/rfcs](https://github.com/bors-ng/rfcs) for broader design
 documentation.

--- a/DELEGATION_INVALIDATION.md
+++ b/DELEGATION_INVALIDATION.md
@@ -213,8 +213,7 @@ handled separately:
 
 ### The truncated-`delta` rule, refined
 
-A naive "any `delta` truncation → revoke" is wrong, and was the original bug
-(see "Why filtering must precede the truncation check"). The truncated overflow
+A naive "any `delta` truncation → revoke" is wrong. The truncated overflow
 is overwhelmingly base-merge files — exactly the noise `pr_diff` strips — so by
 itself it proves nothing. `delta` truncation is only dangerous when it could
 hide the *newness* of an **authored** unacceptable path. So the check is
@@ -232,19 +231,6 @@ filtered, not raw:
 When `pr_diff` itself is truncated (`:no_filter`), we cannot bound the authored
 set, so any `delta` truncation conservatively fails safe — the over-revoke
 direction, consistent with the delta-only fallback above.
-
-### Why filtering must precede the truncation check
-
-The decisive case is mathlib4 PR #39106: the author clicked "Update branch",
-pulling in hundreds of master files. The three-dot `delta`
-(`delegated_at_commit...head`) drags in every file master touched since the
-branch point, so it blows past the 300-file cap on a busy base branch *as a
-matter of course*. The original code returned `:too_large` on that raw size
-before ever filtering, revoking a delegation whose authored diff was a single
-in-scope file — defeating the feature in exactly the scenario the `pr_diff`
-filter was built for. The allow-list's normal rule ("revoke unless every
-authored path is known-acceptable") still drives the decision; we just no longer
-let unseen *base-merge* paths, which are never authored, trip it.
 
 ### Why the split, and "un-actionable delegations"
 

--- a/lib/worker/delegation_invalidator.ex
+++ b/lib/worker/delegation_invalidator.ex
@@ -213,8 +213,9 @@ defmodule BorsNG.Worker.DelegationInvalidator do
   # reason :: {:sensitive, path} | {:out_of_scope, path} | :too_large
   #
   # filter_fun is a thunk returning the pr_diff filter; it is forced only when a
-  # non-empty, non-truncated delta actually needs filtering, so an empty delta
-  # never triggers a pr_diff fetch (the merge-time short-circuit).
+  # non-empty delta actually needs filtering — including a truncated one, which
+  # must be filtered before we react to its size — so an empty delta never
+  # triggers a pr_diff fetch (the merge-time short-circuit).
   @doc false
   def classify_delegation(conn, patch, restrict, deny, filter_fun, delegation) do
     case GitHub.get_pr_compare(conn, delegation.delegated_at_commit, patch.commit) do

--- a/lib/worker/delegation_invalidator.ex
+++ b/lib/worker/delegation_invalidator.ex
@@ -222,19 +222,41 @@ defmodule BorsNG.Worker.DelegationInvalidator do
       {:ok, []} ->
         :ok
 
-      # Hit the compare cap: we cannot enumerate the post-delegation changes,
-      # so a sensitive/out-of-scope path may be hidden. Fail safe.
-      {:ok, files} when length(files) >= @compare_file_cap ->
-        {:revoke, :too_large}
-
       {:ok, files} ->
+        # GitHub caps compare at 300 files with no file pagination, so hitting
+        # the cap means the delta may be incomplete. Crucially we must filter
+        # *before* reacting to that: the delta is dominated by base-merge noise
+        # — clicking "Update branch" drags in every file master touched since
+        # the branch point — and that noise is exactly what the pr_diff filter
+        # removes. Bailing to :too_large on the raw delta size (as we used to)
+        # revokes every delegation the moment the author syncs a busy base
+        # branch like mathlib4's master, which is the very case the filter
+        # exists to allow.
+        truncated? = length(files) >= @compare_file_cap
+        filter = filter_fun.()
+
         files
         |> Enum.map(& &1.filename)
-        |> apply_filter(filter_fun.())
+        |> apply_filter(filter)
         |> Enum.find_value(&classify_path(&1, restrict, deny))
         |> case do
-          nil -> :ok
-          reason -> {:revoke, reason}
+          # A visible authored+new path is unacceptable: revoke with its
+          # specific reason, regardless of truncation.
+          reason when not is_nil(reason) ->
+            {:revoke, reason}
+
+          # Nothing unacceptable among the files we could see. A truncated delta
+          # still leaves uncertainty, but only if some *authored* path is
+          # unacceptable to begin with — otherwise the hidden overflow is all
+          # base-merge noise and cannot mask an unacceptable authored change. So
+          # we fail safe only when truncation could actually be hiding the
+          # newness of an unacceptable authored path.
+          nil ->
+            if truncated? and filter_admits_unacceptable?(filter, restrict, deny) do
+              {:revoke, :too_large}
+            else
+              :ok
+            end
         end
 
       # The GitHub client returns error tuples of several arities, never a bare
@@ -246,6 +268,17 @@ defmodule BorsNG.Worker.DelegationInvalidator do
 
         :unverifiable
     end
+  end
+
+  # Can a truncated delta hide the newness of an unacceptable authored change?
+  # With a complete authored file list it can only do so if some authored path
+  # is unacceptable in the first place. With no filter (pr_diff truncated or
+  # unavailable) we can't bound the authored set, so any truncated delta must
+  # fail safe.
+  defp filter_admits_unacceptable?(:no_filter, _restrict, _deny), do: true
+
+  defp filter_admits_unacceptable?({:filter, set}, restrict, deny) do
+    Enum.any?(set, fn path -> classify_path(path, restrict, deny) != nil end)
   end
 
   # The PR's own file list, used to filter base-merge noise out of a delta.

--- a/test/worker/delegation_invalidator_test.exs
+++ b/test/worker/delegation_invalidator_test.exs
@@ -258,9 +258,38 @@ defmodule BorsNG.Worker.DelegationInvalidatorTest do
     assert Enum.any?(comments, &String.contains?(&1, "src/crypto.rs"))
   end
 
-  test "revokes (too large) when the delta exceeds the compare cap", %{user: user, patch: patch} do
+  test "keeps the delegation when a huge base-merge delta is entirely in scope", %{
+    user: user,
+    patch: patch
+  } do
+    # Regression test for leanprover-community/mathlib4#39106. The author clicked
+    # "Update branch", so the delta from the delegation commit to the new head is
+    # dominated by the 300+ files master touched and blows past the compare cap.
+    # But the author's own net diff (pr_files) is a single in-scope file, so none
+    # of that base-merge churn is authored work — the delegation must survive,
+    # even though the raw delta is truncated.
     put_mock(
       pr_files: ["src/lib.rs"],
+      delta: %{{"old_head", "new_head_sha"} => Enum.map(1..300, &"f#{&1}.rs")}
+    )
+
+    delegate!(user, patch, "old_head")
+
+    DelegationInvalidator.invalidate_for_patch(patch.id)
+
+    assert [_] = Repo.all(UserPatchDelegation)
+    comments = GitHub.ServerMock.get_state() |> get_in([{{:installation, 93}, 23}, :comments, 9])
+    assert comments == []
+  end
+
+  test "revokes (too large) when truncation may hide the newness of an unacceptable authored path",
+       %{user: user, patch: patch} do
+    # Here the author's net diff DOES include a sensitive path (Cargo.toml), and
+    # the delta is truncated, so bors cannot confirm whether the latest push is
+    # what touched it (Cargo.toml isn't among the 300 files it could see). It
+    # fails safe and revokes.
+    put_mock(
+      pr_files: ["Cargo.toml", "src/lib.rs"],
       delta: %{{"old_head", "new_head_sha"} => Enum.map(1..300, &"f#{&1}.rs")}
     )
 


### PR DESCRIPTION
Previously, `classify_delegation/6` checked GitHub's 300-file compare cap *before* filtering and bailed straight to `{:revoke, :too_large}`. But `delta` is the three-dot compare `delegated_at_commit...head`, which is frequently >300 on a busy base branch like mathlib4's master. The cap was hit by base-merge noise the `pr_diff` filter would have stripped, revoking delegations on sync.

Filter first, then fail safe on truncation only when it could hide the *newness* of an authored violation: if every authored path (pr_diff, which paginates to 3000) is in scope, the hidden overflow is pure base-merge noise and can't mask anything, so the delegation stands. A truncated delta now revokes only when some authored path is itself unacceptable. The over-revoke asymmetry is preserved for the genuinely uncertain case.

Replaces the test that enshrined the buggy behavior with a regression test plus the genuinely-dangerous truncated-and-sensitive case, and updates `DELEGATION_INVALIDATION.md`'s truncation policy.

Reported at [leanprover-community/mathlib4#39106](https://github.com/leanprover-community/mathlib4/pull/39106).

Prepared with Claude code.