### PR TITLE
feat(labels): manage PR lifecycle labels in bors

### DIFF
--- a/DELEGATION_INVALIDATION.md
+++ b/DELEGATION_INVALIDATION.md
@@ -85,8 +85,23 @@ change. That asymmetry drives the truncation policy below.
 
 ### bors.toml provenance
 
-`bors.toml` is read from the PR's **base** branch, never the head. A PR cannot
-disable invalidation by editing its own copy of the config.
+`bors.toml` is read from the PR's **base** branch (`patch.into_branch`), never
+the head. A PR cannot disable invalidation by editing its own copy of the
+config; a change to the `[delegation]` options only takes effect once it is
+merged into that base branch. This is also self-consistent: the branch the
+config is read from is the same branch a delegated `r+` would merge into, so the
+only person who can weaken a branch's delegation rules is someone who can already
+push to that branch.
+
+Because the rules are per-base-branch they can differ between branches, and a
+PR's base can change mid-flight — bors updates `into_branch` on the
+`pull_request` *edited* webhook (`Syncer.sync_patch`). A live delegation is
+therefore re-evaluated under the **new** base branch's `[delegation]` options
+after a retarget: its `restrict_to_paths` / `invalidate_on_paths` / expiry may
+differ from the branch it was granted under. To avoid surprises, keep the
+`[delegation]` options uniform across the branches bors manages (`LIFECYCLE_LABELS.md`
+notes the same per-branch consideration for the `delegated` label name). See
+[Known limitations](#known-limitations).
 
 ## Deciding what's acceptable
 
@@ -325,6 +340,12 @@ issued.
   push that both exceeds 300 changed files *and* touches an out-of-scope
   authored path is un-mergeable by a delegate by design: the truncation hides
   whether that path is new, so bors fails safe.
+- **Per-branch config and retargeting.** `[delegation]` options are read from
+  the PR's current base branch, so retargeting a PR (GitHub's *edit base*) moves
+  it onto that branch's rules — a delegation granted under one branch's
+  `restrict_to_paths` / expiry is re-evaluated under the new branch's on the next
+  push or `r+`. Keeping the options uniform across managed branches avoids the
+  surprise; see [bors.toml provenance](#borstoml-provenance).
 
 See also [bors-ng/rfcs](https://github.com/bors-ng/rfcs) for broader design
 documentation.

--- a/DELEGATION_INVALIDATION.md
+++ b/DELEGATION_INVALIDATION.md
@@ -173,6 +173,17 @@ rationale. The advisory `invalidate_on_paths` lint deliberately stays on the
 short budget: its reads (`get_repo_tree`, `get_pr_comments`) only gate a
 cosmetic warning, so a failure just skips it.
 
+### On close or convert-to-draft (full wipe)
+
+Two lifecycle events drop a PR's delegations outright, independent of the
+path-based checks above: **converting the PR to a draft** and **closing it
+without merging**. Both signal the PR is no longer an active candidate to merge
+under the granted trust, so bors wipes every delegation on the patch (and
+reconciles the `delegated` label off). A PR that bors *merges* is left alone —
+its delegations simply expire and are swept normally. These wipes live in the
+`do_webhook_pr` handler; see `LIFECYCLE_LABELS.md` (the `delegated`
+reconcile-points table) for the full lifecycle.
+
 ## GitHub API file ceilings
 
 The two compares hit two different GitHub endpoints with two different,

--- a/LIFECYCLE_LABELS.md
+++ b/LIFECYCLE_LABELS.md
@@ -22,19 +22,13 @@ state.
 
 ## Status
 
-**Implemented on the bors side.** The label write API
-(`BorsNG.GitHub.add_labels/remove_label`), the `[labels]` config, the
-`BorsNG.Worker.Labeler` module, and all the delegation and queue hooks described
-below exist and are covered by tests. Two deliberate scope choices:
-
-- The optional periodic full-reconcile backstop in `Delegation.sweep/0` was
-  **not** implemented; the per-event reconcile in `expire_delegations` (the
-  actual fix) is. The backstop can be added later if drift is ever observed.
-- The queue-label reconcile reads `bors.toml` from the PR's base branch once per
-  batch transition. This is a small, bounded number of extra `get_file` calls
-  per PR lifecycle (negligible against an installation's rate limit); threading
-  the already-fetched toml through the batcher is a possible future
-  optimization.
+**Implemented on the bors side.** The label write/read API
+(`BorsNG.GitHub.add_labels` / `remove_label` / `list_issues_by_label`), the
+`[labels]` config, the `BorsNG.Worker.Labeler` module — both the per-event
+reconciles and the periodic [backstop sweep](#backstop-sweep) — its timer
+(`BorsNG.Worker.LabelBackstopTimer`), the per-base-branch [config
+cache](#config-cache) (`GetBorsToml.get_cached`), and all the delegation and
+queue hooks described below exist and are covered by tests.
 
 The mathlib4 workflow cleanup is **not** done — that lands after this deploys
 (see [Rollout](#rollout-and-sequencing)).
@@ -53,8 +47,8 @@ Bors already owns every piece of state these labels mirror:
   statuses, Zulip notifications) on every transition.
 
 The infrastructure to drive labels from this state already exists; the GitHub
-client merely lacks the write calls, and there is a recurring sweep
-(`BorsNG.Worker.DelegationTimer`) that can act as a self-healing backstop.
+client gains a small set of label write/list calls, and a dedicated recurring
+sweep (`BorsNG.Worker.LabelBackstopTimer`) acts as the self-healing backstop.
 
 The guiding principle, mirroring how the rest of bors treats GitHub side
 effects, is that **labels are best-effort projections of bors's own state**.
@@ -104,11 +98,10 @@ convert-to-draft path), so the label comes off an abandoned PR. A PR that bors
 *merges* is left alone — its delegations expire and get swept in time, and the
 `delegated` label stays as the historical marker described above.
 
-The expiry reconcile is the direct fix for the stranded-label complaint. As a
-backstop, `Delegation.sweep/0` (every ~15 min via `DelegationTimer`) can
-reconcile `delegated` for all patches with active delegations, paced the same
-way it already paces comments, so even a missed event or a restart mid-transition
-converges within one sweep.
+The expiry reconcile is the direct fix for the stranded-label complaint. The
+periodic [backstop sweep](#backstop-sweep) is the second line of defence: even a
+missed event, a dropped best-effort write, or a restart mid-transition converges
+on the next sweep.
 
 ### `ready-to-merge` and `bors-staging`
 
@@ -181,6 +174,10 @@ event** and **sticky** until the next lifecycle move clears it:
   labels untouched, but a PR that merged is not awaiting a re-queue — it reached
   `awaiting-requeue` only via a failure, and re-queuing it would have cleared the
   label before it ever got the chance to merge.)
+
+Because it is event-driven, `awaiting-requeue` is **not** reconciled by the
+[backstop sweep](#backstop-sweep) the way the state-derived labels are; see there
+for why the listing mechanism is the same but the per-PR decision is not.
 
 ## Configuration
 
@@ -271,6 +268,69 @@ guarantee explicit and makes a missed transition self-healing. `awaiting-requeue
 is the exception: it is set/cleared by event, since its desired state is not a
 function of the current DB.
 
+### Backstop sweep
+
+The per-event reconciles keep labels accurate in the normal case, but a label
+can still drift out of sync: a best-effort write dropped at event time, a crash
+mid-transition, or a human editing a managed label by hand.
+`BorsNG.Worker.Labeler.backstop_sweep/0` — run on its own timer
+(`BorsNG.Worker.LabelBackstopTimer`, hourly by default, deliberately decoupled
+from the delegation sweep) — is the self-healing pass for that drift.
+
+It is **discovery-driven and diff-based**. For each project with open patches it
+resolves the per-base-branch `[labels]` config (through the [cache](#config-cache)),
+lists the PRs carrying each managed *state-derived* name with
+`GitHub.list_issues_by_label/2`, and reconciles each. Because that listing
+endpoint returns every PR's full label set, the sweep gets each candidate's
+current labels in the same call it uses to find them, so it diffs locally and a
+tick with no drift performs **zero writes**. A second "add-gap" pass adds a label
+to the (small) set of patches the DB says should be labeled but that surfaced in
+no listing — the one case discovery-by-label can't see: a PR that lost *all* its
+managed labels.
+
+Two properties bound it. It only ever touches **open** patches (`patch.open`),
+so a merged PR's frozen labels are never disturbed — belt-and-suspenders with the
+`state=open` listing filter. And it reconciles a label only where the PR's
+*current* base config manages that name, preserving "never touch foreign labels"
+and the [retarget limitation](#which-branch-the-config-is-read-from).
+
+**Why it sweeps the three state-derived labels but not `awaiting-requeue`.** The
+discovery mechanism would be identical — list the (small) set of PRs carrying the
+label, then reconcile — but the *per-PR decision* is not. For a state-derived
+label the decision is total: the DB always says whether the label should be
+present right now (`delegated` ⇔ an active delegation; `on_queue` / `building` ⇔
+a live batch), so a found label can be kept or removed with confidence.
+`awaiting-requeue` has no current-state predicate — a dropped PR is
+indistinguishable in the DB from one never approved, the whole reason it is
+event-driven — so the sweep can never *add* it, and for a PR carrying only
+`awaiting-requeue` it cannot tell one genuinely awaiting re-queue from a dropped
+`r-`/close clear. The single direction that *is* derivable — clearing it once the
+PR is back on the queue — is the live `reconcile_queue/3` rule, and the backstop
+applies it too: a re-queued PR also carries `on_queue`, so it is already
+discovered (with its full label set, including a stale `awaiting-requeue`) via the
+`on_queue` listing, and the sweep clears the stale label with no dedicated listing
+of its own. What it deliberately does *not* do is list `awaiting-requeue`
+directly: the PRs that would add — carrying it while neither queued nor delegated
+— are exactly the undecidable ones, and that listing's cost would scale with the
+sticky, ever-growing population while deciding almost nothing.
+
+### Config cache
+
+The label reconcile paths re-read the same base-branch `bors.toml` many times —
+the delegation sweep once per expiring patch, the backstop once per PR it touches
+— so a short-TTL cache keyed by `(repo_xref, branch)` collapses those into one
+read per branch per window. `GetBorsToml.get_cached/2` wraps the plain `get/2`,
+backed by an ETS table owned by `…GetBorsToml.Cache`; it caches both successes
+and errors (errors more briefly, so a freshly-added or fixed `bors.toml` is
+picked up promptly) and prunes expired entries periodically. The table is public
+with read concurrency, so the batcher casts, the sweep, and the backstop read it
+without serializing through one process.
+
+It is used **only** by the reconcile paths (the `Labeler` and the delegation
+sweep/backfill). The batcher's merge-decision reads stay on `get/2`: a stale
+config must never drive an actual merge. A non-positive TTL bypasses the cache
+entirely, which is how the test environment keeps config reads fresh.
+
 ### GitHub App permissions
 
 Adding and removing labels requires the installation to hold `issues: write`.
@@ -304,7 +364,8 @@ bors-first, so the expiry fix is live before the Actions stop running:
 - `BorsToml` parse/validation tests for the `[labels]` table (each key present,
   absent, and malformed).
 - Extend the GitHub test double (`lib/github/github/server_mock.ex`, which
-  already stores `labels[issue_xref]`) to handle add and remove.
+  already stores `labels[issue_xref]`) to handle add, remove, and
+  list-by-label.
 - Behavior tests:
   - delegate → `delegated` added; `d-` → removed.
   - **expiry sweep → `delegated` removed** (regression test for the original
@@ -316,6 +377,12 @@ bors-first, so the expiry fix is live before the Actions stop running:
   - terminal failure → `ready-to-merge`/`bors-staging` removed, `awaiting-requeue`
     added; re-`r+` → swapped back.
   - everything is a no-op when `[labels]` is unset.
+- Backstop sweep tests: strands removed (`delegated`/`ready-to-merge`), add-gap
+  re-adds a fully-stripped label, a stale `awaiting-requeue` left alone off the
+  queue but cleared once back on it, a closed/merged PR never touched, and no
+  write when labels already match.
+- Config-cache tests: hit serves a stale value within TTL, expiry/error
+  caching, and a non-positive TTL bypass.
 
 ## Risks and edge cases
 
@@ -328,8 +395,11 @@ bors-first, so the expiry fix is live before the Actions stop running:
   so moving a PR to a branch whose `[labels]` names differ can strand the old
   branch's label. Keeping label names uniform across managed branches avoids it;
   it is otherwise a documented limitation, like manual label edits above.
-- **Rate limits during the sweep** — reuse the existing comment pacing in
-  `Delegation.sweep/0`.
+- **Rate limits during the sweeps.** Label writes are throttled by
+  `Labeler.pace_write/1` (lighter than the comment pacing, since a label write
+  is cheap and idempotent); the backstop's discovery is label-filtered
+  server-side, so it lists only the few PRs carrying a managed label rather than
+  every open PR, and a no-drift tick writes nothing.
 - **`bors-staging` churn.** Every queued PR flickers through `bors-staging` as
   its batch runs. This is inherent to the label's meaning; projects that find it
   noisy simply leave the `building` key unset.

--- a/LIFECYCLE_LABELS.md
+++ b/LIFECYCLE_LABELS.md
@@ -96,6 +96,13 @@ delegation is gone. Reconcile points:
 | Manual revoke (`d-`, `d-=user`) | `run(:undelegate)` / `run({:undelegate_to, _})` in `lib/web/command.ex` |
 | **Timed expiry** | `expire_delegations` in `lib/database/context/delegation.ex` |
 | Sensitive-path revoke | the revoke path in `lib/worker/delegation_invalidator.ex` |
+| Convert-to-draft (wipes delegations) | the `is_draft` clause of `do_webhook_pr`, after `undelegate_patch` |
+| Close without merging (wipes delegations) | the `closed` clause of `do_webhook_pr`, when `pr.merged` is false |
+
+Closing a PR without merging now also **wipes its delegations** (mirroring the
+convert-to-draft path), so the label comes off an abandoned PR. A PR that bors
+*merges* is left alone — its delegations expire and get swept in time, and the
+`delegated` label stays as the historical marker described above.
 
 The expiry reconcile is the direct fix for the stranded-label complaint. As a
 backstop, `Delegation.sweep/0` (every ~15 min via `DelegationTimer`) can
@@ -132,16 +139,23 @@ the existing batcher transitions, all of which already fire `send_status` /
 
 | Transition | Site | Effect |
 |------------|------|--------|
-| Patch reviewed (`r+`) → enters a `:waiting` batch | `do_handle_cast({:reviewed, …})` | + `ready-to-merge` |
+| Patch reviewed (`r+`) → enters a `:waiting` batch | `run` (via `do_handle_cast({:reviewed, …})`) | + `ready-to-merge`, − `awaiting-requeue` |
 | Batch `:waiting` → `:running` | `start_waiting_batch` | + `bors-staging` |
-| Batch completes `:ok` (merged) | `complete_batch` | − both (PR also closes) |
-| Batch completes `:error` / `:conflict` | `complete_batch` | − both (+ `awaiting-requeue`, see below) |
-| Cancel (`r-`) / `cancel_all` | `cancel` / `cancel_all` | − both |
-| PR closed | the `l.patch.open == false` reject in `poll` | − both |
+| Batch merges `:ok` | `maybe_complete_batch` | **labels left in place** (frozen as history; see below) |
+| Batch fails terminally (`:error` / `:conflict` / timeout) | `maybe_complete_batch` / `start_waiting_batch` / `timeout_batch` | − `ready-to-merge` / `bors-staging`, + `awaiting-requeue` |
+| Cancel (`r-`) / `cancel_all` | `cancel_patch` / `cancel_all` | − both |
+| PR closed without merging | `closed` webhook → `Batcher.cancel` | − both (also wipes delegations, see [`delegated`](#delegated)) |
 
 Because batches are reconciled from truth, bisection (a failed multi-PR batch
 splitting and re-running its halves) needs no special handling: a patch's labels
 simply track whatever batch state it currently sits in.
+
+**A successful merge is the one transition that does *not* reconcile.** The PR
+closes, so its labels can no longer drift, and leaving them in place turns
+`ready-to-merge` / `delegated` into a (best-effort) historical record of how the
+PR merged — in particular, which merged PRs had been delegated. Failures leave
+the PR *open*, so those still reconcile their queue labels off. The asymmetry is
+deliberate: open PRs reflect live state, closed-by-merge PRs are frozen.
 
 ### `awaiting-requeue` (event-driven)
 
@@ -161,9 +175,12 @@ event** and **sticky** until the next lifecycle move clears it:
   once a size-1 batch fails (the natural endpoint of bisection). Labeling at the
   terminal point — not mid-bisection — keeps the label meaning "needs a human to
   re-queue," not "is somewhere in a retry."
-- **Cleared** on re-`r+` (which re-adds `ready-to-merge`), `r-`, PR close, or a
-  successful merge. Re-queuing therefore swaps `awaiting-requeue` back to
-  `ready-to-merge`; the two are never both present.
+- **Cleared** on re-`r+` (which re-adds `ready-to-merge`), `r-`, or a PR close
+  without merging. Re-queuing therefore swaps `awaiting-requeue` back to
+  `ready-to-merge`; the two are never both present. (A *successful merge* leaves
+  labels untouched, but a PR that merged is not awaiting a re-queue — it reached
+  `awaiting-requeue` only via a failure, and re-queuing it would have cleared the
+  label before it ever got the chance to merge.)
 
 ## Configuration
 

--- a/LIFECYCLE_LABELS.md
+++ b/LIFECYCLE_LABELS.md
@@ -1,0 +1,290 @@
+# PR Lifecycle Labels
+
+Some projects mark a pull request's place in the merge pipeline with GitHub
+labels — `ready-to-merge` for "approved and queued," `delegated` for "someone
+has been handed approval rights." Today, on `leanprover-community/mathlib4`,
+those labels are driven by GitHub Actions that parse `bors` commands out of
+comments (`maintainer_bors.yml` → `maintainer_bors_wf_run.yml`). That approach
+can only react to comments and PR events, so it is structurally blind to state
+changes that happen *inside* bors with no comment to trigger on.
+
+The most visible casualty is the **`delegated` label that never goes away**.
+Since delegations gained an expiry (`DELEGATION_INVALIDATION.md` and the
+`[delegation] default_expiry_sec` feature), a delegation can end in three ways
+the Actions never see: it can **time out** during `Delegation.sweep/0`, it can
+be **revoked by a sensitive-path push** in the invalidator, or it can simply be
+the *last* of several delegations to be removed. In all of these the label is
+left stranded on the PR.
+
+This document proposes moving label management into bors itself, where the
+state already lives, and defines a small set of lifecycle labels driven by that
+state.
+
+## Status
+
+**Implemented on the bors side.** The label write API
+(`BorsNG.GitHub.add_labels/remove_label`), the `[labels]` config, the
+`BorsNG.Worker.Labeler` module, and all the delegation and queue hooks described
+below exist and are covered by tests. Two deliberate scope choices:
+
+- The optional periodic full-reconcile backstop in `Delegation.sweep/0` was
+  **not** implemented; the per-event reconcile in `expire_delegations` (the
+  actual fix) is. The backstop can be added later if drift is ever observed.
+- The queue-label reconcile reads `bors.toml` from the PR's base branch once per
+  batch transition. This is a small, bounded number of extra `get_file` calls
+  per PR lifecycle (negligible against an installation's rate limit); threading
+  the already-fetched toml through the batcher is a possible future
+  optimization.
+
+The mathlib4 workflow cleanup is **not** done — that lands after this deploys
+(see [Rollout](#rollout-and-sequencing)).
+
+## Why bors, not GitHub Actions
+
+Bors already owns every piece of state these labels mirror:
+
+- **Delegations** live in the `user_patch_delegations` table and change in four
+  places — creation (`bors d+`/`d=`), manual revoke (`bors d-`), **timed
+  expiry** (`Delegation.sweep/0`, `lib/database/context/delegation.ex`), and
+  **sensitive-path invalidation** (`lib/worker/delegation_invalidator.ex`).
+  Only the first two produce anything a comment-driven workflow can observe.
+- **Queue membership** is the `LinkPatchBatch` → `Batch` state machine in
+  `lib/worker/batcher.ex`, which already emits side effects (PR comments, commit
+  statuses, Zulip notifications) on every transition.
+
+The infrastructure to drive labels from this state already exists; the GitHub
+client merely lacks the write calls, and there is a recurring sweep
+(`BorsNG.Worker.DelegationTimer`) that can act as a self-healing backstop.
+
+The guiding principle, mirroring how the rest of bors treats GitHub side
+effects, is that **labels are best-effort projections of bors's own state**.
+They are reconciled toward the truth in the database; a failed label API call
+is logged and dropped, never allowed to crash a batcher cast or the delegation
+sweep.
+
+## The labels
+
+| Label | Means | Driven by |
+|-------|-------|-----------|
+| `delegated` | the PR has ≥1 active (non-expired) delegation | state (DB) |
+| `ready-to-merge` | the PR is on the queue — a batch in `:waiting` **or** `:running` | state (DB) |
+| `bors-staging` | the PR is actively building on the staging branch (`:running`) | state (DB) |
+| `awaiting-requeue` | the PR was approved, its build failed terminally, and it was dropped | event (sticky) |
+
+Three of the four are **state-derived**: their presence is a pure function of
+the current database, so they are *reconciled* rather than toggled, and any
+missed transition self-corrects on the next reconcile. The fourth,
+`awaiting-requeue`, cannot be derived from current state (a dropped PR is
+indistinguishable in the DB from one that was never approved) and is therefore
+**event-driven and sticky** — set on terminal failure, cleared on the next
+lifecycle move. See [`awaiting-requeue`](#awaiting-requeue-event-driven) for why.
+
+### `delegated`
+
+Present iff the patch has at least one delegation whose `expires_at` is null or
+in the future — the same predicate `Permission.permission?(:reviewer, …)`
+already uses (`patch_delegated_reviewer?`, `lib/database/context/permission.ex`),
+generalized to "any active delegation on this patch."
+
+Reconciled — not blindly removed — because a PR can carry several delegations
+(`bors d=alice,bob`). The label must persist until the **last** active
+delegation is gone. Reconcile points:
+
+| Event | Site |
+|-------|------|
+| Delegate created | `delegate_to` in `lib/web/command.ex`, after `Permission.delegate` |
+| Manual revoke (`d-`, `d-=user`) | `run(:undelegate)` / `run({:undelegate_to, _})` in `lib/web/command.ex` |
+| **Timed expiry** | `expire_delegations` in `lib/database/context/delegation.ex` |
+| Sensitive-path revoke | the revoke path in `lib/worker/delegation_invalidator.ex` |
+
+The expiry reconcile is the direct fix for the stranded-label complaint. As a
+backstop, `Delegation.sweep/0` (every ~15 min via `DelegationTimer`) can
+reconcile `delegated` for all patches with active delegations, paced the same
+way it already paces comments, so even a missed event or a restart mid-transition
+converges within one sweep.
+
+### `ready-to-merge` and `bors-staging`
+
+`ready-to-merge` marks "in the merge pipeline": the patch is linked to a batch
+in `:waiting` or `:running`. `bors-staging` marks the narrower "burning CI right
+now": linked to a batch in `:running`.
+
+**`bors-staging` is an additive overlay, not a replacement.** A PR that is
+building carries *both* labels. This is a deliberate choice over making them
+mutually exclusive (`ready-to-merge` = waiting-only, `bors-staging` = running):
+
+- **Decoupled configuration.** `ready-to-merge` behaves identically whether or
+  not `bors-staging` is configured, so a project can adopt or drop the staging
+  overlay later without ever changing what `ready-to-merge` means. The exclusive
+  model would couple the two config keys and silently redefine `ready-to-merge`
+  the moment the overlay is enabled.
+- **Preserved meaning.** `ready-to-merge` keeps its established sense of
+  "approved and in the pipeline," so existing filters and habits don't break.
+
+So `ready-to-merge` answers "what's in the pipeline?" and `bors-staging` answers
+"what is the merge build chewing on right now?" — the latter a strict subset of
+the former.
+
+Both are state-derived, so the cleanest implementation queries the desired set
+and diffs (see [Reconciliation](#reconciliation)). Natural reconcile points are
+the existing batcher transitions, all of which already fire `send_status` /
+`send_zulip`:
+
+| Transition | Site | Effect |
+|------------|------|--------|
+| Patch reviewed (`r+`) → enters a `:waiting` batch | `do_handle_cast({:reviewed, …})` | + `ready-to-merge` |
+| Batch `:waiting` → `:running` | `start_waiting_batch` | + `bors-staging` |
+| Batch completes `:ok` (merged) | `complete_batch` | − both (PR also closes) |
+| Batch completes `:error` / `:conflict` | `complete_batch` | − both (+ `awaiting-requeue`, see below) |
+| Cancel (`r-`) / `cancel_all` | `cancel` / `cancel_all` | − both |
+| PR closed | the `l.patch.open == false` reject in `poll` | − both |
+
+Because batches are reconciled from truth, bisection (a failed multi-PR batch
+splitting and re-running its halves) needs no special handling: a patch's labels
+simply track whatever batch state it currently sits in.
+
+### `awaiting-requeue` (event-driven)
+
+This is the replacement for an existing workaround: maintainers have been using
+the *stale* `ready-to-merge` label to find PRs that were approved but whose
+build failed, so they can put them back on the queue. Once `ready-to-merge`
+accurately tracks live queue membership (and so comes off on failure), that
+signal would be lost — `awaiting-requeue` restores it as a first-class state.
+
+It cannot be reconciled from current state: once a batch fails, bors returns the
+patch to the same "awaiting review" condition as a PR that was never approved —
+there is no "it failed" flag to read. So `awaiting-requeue` is **set on the
+event** and **sticky** until the next lifecycle move clears it:
+
+- **Set** when a batch fails **terminally for a single PR**. Bors bisects
+  multi-PR batches and re-runs the halves, so a PR is only genuinely *dropped*
+  once a size-1 batch fails (the natural endpoint of bisection). Labeling at the
+  terminal point — not mid-bisection — keeps the label meaning "needs a human to
+  re-queue," not "is somewhere in a retry."
+- **Cleared** on re-`r+` (which re-adds `ready-to-merge`), `r-`, PR close, or a
+  successful merge. Re-queuing therefore swaps `awaiting-requeue` back to
+  `ready-to-merge`; the two are never both present.
+
+## Configuration
+
+Label management is **opt-in per project** via a new `[labels]` table in
+`bors.toml`, parsed into flat fields on `BorsNG.Worker.Batcher.BorsToml`
+alongside the existing `delegation_*` fields:
+
+```toml
+[labels]
+on_queue  = "ready-to-merge"    # batch waiting or running
+building  = "bors-staging"      # batch running (overlay on on_queue)
+failed    = "awaiting-requeue"  # terminal build failure, awaiting re-queue
+delegated = "delegated"
+```
+
+- Each value is a single label name (`binary`), or absent. **Absent ⇒ that
+  label is unmanaged**, so every project that does not configure `[labels]` —
+  i.e. every current bors user other than mathlib4 — sees no behavior change at
+  all. Each label can be adopted independently.
+- Keys are named by **meaning** (`on_queue`, `building`, `failed`, `delegated`),
+  not by mathlib4's chosen label text, so other projects can reuse them with
+  their own names.
+- Validation, in the style of the existing `block_labels` / `delegation_*`
+  checks in `bors_toml.ex`: each value must be a non-empty string or absent;
+  anything else is a `bors.toml` configuration error with a clear message.
+
+## Architecture
+
+### GitHub write calls
+
+The client (`lib/github/github.ex`, backend `lib/github/github/server.ex`) has
+read-only label support today: `get_labels/2`. Two writes are added, mirroring
+its structure and going through the same `BorsNG.GitHub` GenServer:
+
+- `add_labels(repo_conn, issue_xref, [label])` → `POST issues/{n}/labels` with
+  body `%{"labels" => [...]}`. Idempotent server-side (GitHub does not duplicate
+  an existing label).
+- `remove_label(repo_conn, issue_xref, label)` →
+  `DELETE issues/{n}/labels/{URI.encode_www_form(label)}`. A `404` (label already
+  absent) is treated as success.
+
+Unlike the delegation compares, these need no extended retry budget: they are
+best-effort projections, so a transient failure is logged and dropped, to be
+re-reconciled later — never retried to the point of stalling a caller.
+
+### Reconciliation
+
+A small `Labeler` module centralizes the logic. For the state-derived labels it
+**reconciles** rather than toggling, touching only the labels bors manages and
+never any unrelated label:
+
+```
+managed   = the configured label name for this concern (0 or 1 names)
+desired    = should that label be present right now?  (from the DB)
+to_add     = desired − current
+to_remove  = (managed ∩ current) − desired
+```
+
+Because each concern manages at most one label name, this is a one-element set
+operation, but framing it as a diff keeps the "never touch foreign labels"
+guarantee explicit and makes a missed transition self-healing. `awaiting-requeue`
+is the exception: it is set/cleared by event, since its desired state is not a
+function of the current DB.
+
+### GitHub App permissions
+
+Adding and removing labels requires the installation to hold `issues: write`.
+Bors already posts PR comments (issue comments), which need the same scope, so
+this is almost certainly already granted — but it should be confirmed on the
+mathlib4 installation before rollout, since a missing scope would surface only
+as silently-dropped label calls.
+
+## Rollout and sequencing
+
+Label operations are idempotent, so bors and the existing Actions can safely
+manage the same labels during the overlap. The order that matters is
+bors-first, so the expiry fix is live before the Actions stop running:
+
+1. Ship and deploy the bors feature with `[labels]` **unset** — a no-op
+   everywhere, including mathlib4.
+2. Add `[labels]` to mathlib4's `bors.toml`. Bors begins managing the labels;
+   the Actions still also manage `ready-to-merge` / `delegated` (both just add
+   the same label — harmless).
+3. Watch one delegation-expiry cycle to confirm bors removes `delegated` on
+   timeout.
+4. Strip only the `ready-to-merge` / `delegated` add/remove logic from
+   `maintainer_bors.yml` and `maintainer_bors_wf_run.yml`. Everything else in
+   those workflows — permission checks, `awaiting-author` / `maintainer-merge`
+   cleanup — stays. The `Build failed:` → `delegated` re-apply quirk disappears
+   naturally: bors keeps `delegated` for as long as the delegation is actually
+   active, regardless of build failures.
+
+## Testing
+
+- `BorsToml` parse/validation tests for the `[labels]` table (each key present,
+  absent, and malformed).
+- Extend the GitHub test double (`lib/github/github/server_mock.ex`, which
+  already stores `labels[issue_xref]`) to handle add and remove.
+- Behavior tests:
+  - delegate → `delegated` added; `d-` → removed.
+  - **expiry sweep → `delegated` removed** (regression test for the original
+    complaint).
+  - sensitive-path revoke → `delegated` removed.
+  - multiple delegatees → `delegated` persists until the last is gone.
+  - `r+` → `ready-to-merge`; batch start → `+ bors-staging`; merge/cancel →
+    both removed.
+  - terminal failure → `ready-to-merge`/`bors-staging` removed, `awaiting-requeue`
+    added; re-`r+` → swapped back.
+  - everything is a no-op when `[labels]` is unset.
+
+## Risks and edge cases
+
+- **App scope** (`issues: write`) — verify on the installation (see above).
+- **Manual label edits.** Bors only ever touches its managed set, so a
+  human-removed `delegated` is re-added on the next reconcile. This is intended:
+  the label is a projection of bors state, not an independent annotation.
+- **Rate limits during the sweep** — reuse the existing comment pacing in
+  `Delegation.sweep/0`.
+- **`bors-staging` churn.** Every queued PR flickers through `bors-staging` as
+  its batch runs. This is inherent to the label's meaning; projects that find it
+  noisy simply leave the `building` key unset.
+
+See also [bors-ng/rfcs](https://github.com/bors-ng/rfcs) for broader design
+documentation.

--- a/LIFECYCLE_LABELS.md
+++ b/LIFECYCLE_LABELS.md
@@ -190,6 +190,32 @@ delegated = "delegated"
   checks in `bors_toml.ex`: each value must be a non-empty string or absent;
   anything else is a `bors.toml` configuration error with a clear message.
 
+### Which branch the config is read from
+
+The `[labels]` config is read from the **PR's base branch** (`patch.into_branch`)
+— the current tip of the branch the PR targets — never from the PR's own head.
+This matches how the `[delegation]` options are read, and gives the same safety
+property: a PR cannot change the label (or delegation) rules it is evaluated
+under by editing `bors.toml` in the PR itself; the change only takes effect once
+it is merged into that base branch. It is also self-consistent — the branch the
+config is read from is the same branch the batch merges into, so the only person
+who can weaken a branch's config is someone who can already push to that branch.
+
+Because config is per-base-branch, a project whose branches carry **different**
+`[labels]` names can strand a label across a **base-branch retarget**. The
+reconcile only ever touches the names configured on the PR's *current* base (the
+"never touch foreign labels" guarantee, see [Reconciliation](#reconciliation));
+if a PR is moved from a branch where `on_queue = "ready-to-merge"` to one where
+it is `"queued"` (or unset), the `ready-to-merge` it picked up earlier is now
+unmanaged and is left stranded — and bors updates `into_branch` live on the
+`pull_request` *edited* webhook, so the switch is immediate.
+
+**Recommendation: keep the `[labels]` names (and, ideally, the `[delegation]`
+options) uniform across the branches bors manages.** If the managed *names* are
+branch-invariant, the managed set never changes on a retarget and nothing
+strands — the configs may still legitimately differ in other ways. For mathlib4
+this is automatic, since PRs effectively target a single branch.
+
 ## Architecture
 
 ### GitHub write calls
@@ -280,6 +306,11 @@ bors-first, so the expiry fix is live before the Actions stop running:
 - **Manual label edits.** Bors only ever touches its managed set, so a
   human-removed `delegated` is re-added on the next reconcile. This is intended:
   the label is a projection of bors state, not an independent annotation.
+- **Base-branch retarget with divergent label names.** Config is read per base
+  branch (see [Which branch the config is read from](#which-branch-the-config-is-read-from)),
+  so moving a PR to a branch whose `[labels]` names differ can strand the old
+  branch's label. Keeping label names uniform across managed branches avoids it;
+  it is otherwise a documented limitation, like manual label edits above.
 - **Rate limits during the sweep** — reuse the existing comment pacing in
   `Delegation.sweep/0`.
 - **`bors-staging` churn.** Every queued PR flickers through `bors-staging` as

--- a/config/config.exs
+++ b/config/config.exs
@@ -27,7 +27,12 @@ config :bors,
   api_github_timeout: {:system, :integer, "GITHUB_API_TIMEOUT", 100_000},
   log_outgoing: {:system, "BORS_LOG_OUTGOING", false},
   poll_period: {:system, :integer, "BORS_POLL_PERIOD", 1_800_000},
-  delegation_sweep_period: {:system, :integer, "BORS_DELEGATION_SWEEP_PERIOD", 600_000}
+  delegation_sweep_period: {:system, :integer, "BORS_DELEGATION_SWEEP_PERIOD", 600_000},
+  label_backstop_period: {:system, :integer, "BORS_LABEL_BACKSTOP_PERIOD", 3_600_000},
+  label_write_pace_ms: {:system, :integer, "BORS_LABEL_WRITE_PACE_MS", 250},
+  bors_toml_cache_ttl_ms: {:system, :integer, "BORS_TOML_CACHE_TTL_MS", 120_000},
+  bors_toml_cache_error_ttl_ms: {:system, :integer, "BORS_TOML_CACHE_ERROR_TTL_MS", 15_000},
+  bors_toml_cache_prune_period_ms: {:system, :integer, "BORS_TOML_CACHE_PRUNE_PERIOD_MS", 600_000}
 
 config :bors,
   zulip_api_url: {:system, "ZULIP_API_URL", ""},

--- a/config/test.exs
+++ b/config/test.exs
@@ -23,4 +23,9 @@ config :bors, :server, BorsNG.GitHub.ServerMock
 config :bors, :oauth2, BorsNG.GitHub.OAuth2Mock
 config :bors, :is_test, true
 
+# Bypass the bors.toml reconcile-path cache in tests so a test that rewrites a
+# repo's bors.toml mid-run always observes the new config. The `get_cached/2`
+# code path is still exercised; it just always falls through to `get/2`.
+config :bors, :bors_toml_cache_ttl_ms, 0
+
 config :bors, :celebrate_new_year, false

--- a/lib/application.ex
+++ b/lib/application.ex
@@ -56,6 +56,11 @@ defmodule BorsNG.Application do
       },
       %{type: :worker, id: BorsNG.Attrs, start: {BorsNG.Attrs, :start_link, []}},
       %{
+        type: :worker,
+        id: BorsNG.Worker.Batcher.GetBorsToml.Cache,
+        start: {BorsNG.Worker.Batcher.GetBorsToml.Cache, :start_link, []}
+      },
+      %{
         type: :supervisor,
         id: BorsNG.Worker.Batcher.Supervisor,
         start: {BorsNG.Worker.Batcher.Supervisor, :start_link, []}
@@ -111,6 +116,15 @@ defmodule BorsNG.Application do
           []
         },
         id: BorsNG.Worker.DelegationTimer
+      },
+      %{
+        type: :worker,
+        start: {
+          BorsNG.Worker.LabelBackstopTimer,
+          :start_link,
+          []
+        },
+        id: BorsNG.Worker.LabelBackstopTimer
       },
       %{
         type: :supervisor,

--- a/lib/application.ex
+++ b/lib/application.ex
@@ -56,11 +56,6 @@ defmodule BorsNG.Application do
       },
       %{type: :worker, id: BorsNG.Attrs, start: {BorsNG.Attrs, :start_link, []}},
       %{
-        type: :worker,
-        id: BorsNG.Worker.Batcher.GetBorsToml.Cache,
-        start: {BorsNG.Worker.Batcher.GetBorsToml.Cache, :start_link, []}
-      },
-      %{
         type: :supervisor,
         id: BorsNG.Worker.Batcher.Supervisor,
         start: {BorsNG.Worker.Batcher.Supervisor, :start_link, []}
@@ -135,7 +130,16 @@ defmodule BorsNG.Application do
         },
         id: BorsNG.Endpoint
       },
-      {Phoenix.PubSub, name: BorsNG.PubSub}
+      {Phoenix.PubSub, name: BorsNG.PubSub},
+      # The bors.toml config cache is an optional optimization the workers
+      # tolerate missing (get_cached/2 falls back to an uncached read when its
+      # ETS table is absent), so under rest_for_one it sits last: a restart of
+      # this process can't cascade into the batcher, registries, or endpoint.
+      %{
+        type: :worker,
+        id: BorsNG.Worker.Batcher.GetBorsToml.Cache,
+        start: {BorsNG.Worker.Batcher.GetBorsToml.Cache, :start_link, []}
+      }
     ]
 
     # See http://elixir-lang.org/docs/stable/elixir/Supervisor.html

--- a/lib/database/context/delegation.ex
+++ b/lib/database/context/delegation.ex
@@ -151,11 +151,16 @@ defmodule BorsNG.Database.Context.Delegation do
       # deletes so the label reflects whether *any* delegation still stands;
       # this is the fix for the label being stranded when a delegation times
       # out (there's no GitHub event a workflow could react to).
+      #
+      # Paced with the lighter label throttle, not `pace_comment`: this loop
+      # only writes labels (no comments), so the ~750ms content-creation budget
+      # would just be dead sleep. `d.patch` carries its preloaded `:project`, so
+      # `reconcile_delegated/1` reuses it rather than re-reading the project.
       expired_open
       |> Enum.uniq_by(& &1.patch_id)
       |> Enum.with_index()
       |> Enum.each(fn {d, idx} ->
-        pace_comment(idx)
+        Labeler.pace_write(idx)
         Labeler.reconcile_delegated(d.patch)
       end)
     end
@@ -223,7 +228,10 @@ defmodule BorsNG.Database.Context.Delegation do
     project = Repo.get!(Project, patch.project_id)
     conn = Project.installation_connection(project.repo_xref, Repo)
 
-    case GetBorsToml.get(conn, patch.into_branch) do
+    # Sweep-time read: a slightly stale default-expiry config self-corrects on
+    # the next sweep, and the eager command/preflight path always reads fresh,
+    # so the cache is safe here and spares the sweep a per-patch GitHub read.
+    case GetBorsToml.get_cached(conn, patch.into_branch) do
       {:ok, toml} -> reconcile_default_expiry(patch, toml.delegation_default_expiry_sec)
       {:error, _} -> []
     end

--- a/lib/database/context/delegation.ex
+++ b/lib/database/context/delegation.ex
@@ -31,6 +31,7 @@ defmodule BorsNG.Database.Context.Delegation do
   alias BorsNG.Command
   alias BorsNG.GitHub
   alias BorsNG.Worker.Batcher.GetBorsToml
+  alias BorsNG.Worker.Labeler
 
   require Logger
 
@@ -136,12 +137,26 @@ defmodule BorsNG.Database.Context.Delegation do
 
       Repo.delete_all(from(d in UserPatchDelegation, where: d.id in ^ids))
 
-      expired
-      |> Enum.filter(&(&1.patch && &1.patch.open && &1.patch.project))
+      expired_open = Enum.filter(expired, &(&1.patch && &1.patch.open && &1.patch.project))
+
+      expired_open
       |> Enum.with_index()
       |> Enum.each(fn {d, idx} ->
         pace_comment(idx)
         post_expired_comment(d)
+      end)
+
+      # Reconcile the `delegated` label once per affected patch — a patch may
+      # have had several delegations expire in the same tick. Done after the
+      # deletes so the label reflects whether *any* delegation still stands;
+      # this is the fix for the label being stranded when a delegation times
+      # out (there's no GitHub event a workflow could react to).
+      expired_open
+      |> Enum.uniq_by(& &1.patch_id)
+      |> Enum.with_index()
+      |> Enum.each(fn {d, idx} ->
+        pace_comment(idx)
+        Labeler.reconcile_delegated(d.patch)
       end)
     end
   end

--- a/lib/database/context/permission.ex
+++ b/lib/database/context/permission.ex
@@ -97,6 +97,23 @@ defmodule BorsNG.Database.Context.Permission do
     |> Kernel.not()
   end
 
+  @doc """
+  Whether the patch currently carries any active (non-expired) delegation,
+  regardless of who it's delegated to. Drives the `delegated` label: it stays on
+  until the last delegatee is gone. Uses the same lazy-expiry rule as
+  `patch_delegated_reviewer?/2`.
+  """
+  def patch_has_active_delegation?(patch_id) do
+    now = NaiveDateTime.utc_now()
+
+    UserPatchDelegation
+    |> where(
+      [d],
+      d.patch_id == ^patch_id and (is_nil(d.expires_at) or d.expires_at > ^now)
+    )
+    |> Repo.exists?()
+  end
+
   def delegate(user, patch, opts \\ []) do
     expires_at = Keyword.get(opts, :expires_at)
     delegated_at_commit = Keyword.get(opts, :delegated_at_commit)

--- a/lib/github/github.ex
+++ b/lib/github/github.ex
@@ -245,6 +245,26 @@ defmodule BorsNG.GitHub do
     call_with_retry(:get_labels, repo_conn, {issue_xref}, 500, 4_000)
   end
 
+  @doc """
+  Add labels to a PR or issue. Idempotent: GitHub does not duplicate a label
+  that is already present. An empty list is a no-op (no API call).
+  """
+  @spec add_labels(tconn, integer | bitstring, [bitstring]) :: :ok | {:error, term}
+  def add_labels(_repo_conn, _issue_xref, []), do: :ok
+
+  def add_labels(repo_conn, issue_xref, labels) when is_list(labels) do
+    call_with_retry(:add_labels, repo_conn, {issue_xref, labels}, 500, 4_000)
+  end
+
+  @doc """
+  Remove a single label from a PR or issue. Idempotent: a label that is already
+  absent (GitHub responds `404`) is treated as success.
+  """
+  @spec remove_label(tconn, integer | bitstring, bitstring) :: :ok | {:error, term}
+  def remove_label(repo_conn, issue_xref, label) do
+    call_with_retry(:remove_label, repo_conn, {issue_xref, label}, 500, 4_000)
+  end
+
   @spec get_reviews!(tconn, integer | bitstring) :: map
   def get_reviews!(repo_conn, issue_xref) do
     {:ok, labels} = get_reviews(repo_conn, issue_xref)

--- a/lib/github/github.ex
+++ b/lib/github/github.ex
@@ -265,6 +265,20 @@ defmodule BorsNG.GitHub do
     call_with_retry(:remove_label, repo_conn, {issue_xref, label}, 500, 4_000)
   end
 
+  @doc """
+  List the open issues/PRs in the repo that currently carry `label`, each paired
+  with its full set of label names (as the GitHub issues endpoint returns them).
+
+  Drives the label backstop sweep (LIFECYCLE_LABELS.md): the labels in the
+  response feed a diff against bors's own state, so a sweep that finds no drift
+  performs no writes.
+  """
+  @spec list_issues_by_label(tconn, bitstring) ::
+          {:ok, [{integer, [bitstring]}]} | {:error, term}
+  def list_issues_by_label(repo_conn, label) do
+    call_with_retry(:list_issues_by_label, repo_conn, {label}, 500, 4_000)
+  end
+
   @spec get_reviews!(tconn, integer | bitstring) :: map
   def get_reviews!(repo_conn, issue_xref) do
     {:ok, labels} = get_reviews(repo_conn, issue_xref)
@@ -590,13 +604,16 @@ defmodule BorsNG.GitHub do
     Confex.get_env(:bors, :api_github_retry_max_elapsed_ms, 180_000)
   end
 
-  # Label writes are best-effort projections of bors's own state
-  # (LIFECYCLE_LABELS.md): a dropped one is re-reconciled on the next lifecycle
-  # event, so it is never worth grinding retries that serially block the batcher
-  # or the delegation sweep. The acute case is a missing `issues: write` scope,
-  # where every call 403s and the write budget below would burn ~10 attempts /
-  # ~30s apiece. Give them an essentially single-shot budget instead.
-  defp max_retry_elapsed_ms(action) when action in [:add_labels, :remove_label] do
+  # Label operations are best-effort projections of bors's own state
+  # (LIFECYCLE_LABELS.md): a dropped write is re-reconciled on the next
+  # lifecycle event or backstop sweep, so it is never worth grinding retries
+  # that serially block the batcher or the sweeps. The acute case is a missing
+  # `issues: write` scope, where every call 403s and the write budget below
+  # would burn ~10 attempts / ~30s apiece. The backstop's own label listing
+  # rides the same budget: giving up early just means it re-runs next tick.
+  # Give them all an essentially single-shot budget instead.
+  defp max_retry_elapsed_ms(action)
+       when action in [:add_labels, :remove_label, :list_issues_by_label] do
     Confex.get_env(:bors, :api_github_retry_label_max_elapsed_ms, 1_000)
   end
 

--- a/lib/github/github.ex
+++ b/lib/github/github.ex
@@ -590,6 +590,16 @@ defmodule BorsNG.GitHub do
     Confex.get_env(:bors, :api_github_retry_max_elapsed_ms, 180_000)
   end
 
+  # Label writes are best-effort projections of bors's own state
+  # (LIFECYCLE_LABELS.md): a dropped one is re-reconciled on the next lifecycle
+  # event, so it is never worth grinding retries that serially block the batcher
+  # or the delegation sweep. The acute case is a missing `issues: write` scope,
+  # where every call 403s and the write budget below would burn ~10 attempts /
+  # ~30s apiece. Give them an essentially single-shot budget instead.
+  defp max_retry_elapsed_ms(action) when action in [:add_labels, :remove_label] do
+    Confex.get_env(:bors, :api_github_retry_label_max_elapsed_ms, 1_000)
+  end
+
   defp max_retry_elapsed_ms(_action) do
     Confex.get_env(:bors, :api_github_retry_write_max_elapsed_ms, 30_000)
   end

--- a/lib/github/github/server.ex
+++ b/lib/github/github/server.ex
@@ -430,6 +430,35 @@ defmodule BorsNG.GitHub.Server do
     end
   end
 
+  def do_handle_call(:add_labels, repo_conn, {issue_xref, labels}) do
+    repo_conn
+    |> post!("issues/#{issue_xref}/labels", Jason.encode!(%{labels: labels}))
+    |> case do
+      %{status: status} when status in [200, 201] ->
+        :ok
+
+      %{body: body, status: status} ->
+        {:error, :add_labels, status, body}
+    end
+  end
+
+  def do_handle_call(:remove_label, repo_conn, {issue_xref, label}) do
+    # The label name is a path segment; `delete!` runs the whole path through
+    # `URI.encode`, which escapes spaces but not `/`. Bors-managed labels are
+    # simple kebab-case names with neither, so this is fine in practice. A 404
+    # means the label was already absent, which is success for an idempotent
+    # remove.
+    repo_conn
+    |> delete!("issues/#{issue_xref}/labels/#{label}")
+    |> case do
+      %{status: status} when status in [200, 404] ->
+        :ok
+
+      %{body: body, status: status} ->
+        {:error, :remove_label, status, body}
+    end
+  end
+
   def do_handle_call(:get_reviews, {{:raw, token}, repo_xref}, {issue_xref, sha}) do
     reviews =
       token

--- a/lib/github/github/server.ex
+++ b/lib/github/github/server.ex
@@ -442,14 +442,19 @@ defmodule BorsNG.GitHub.Server do
     end
   end
 
-  def do_handle_call(:remove_label, repo_conn, {issue_xref, label}) do
-    # The label name is a path segment; `delete!` runs the whole path through
-    # `URI.encode`, which escapes spaces but not `/`. Bors-managed labels are
-    # simple kebab-case names with neither, so this is fine in practice. A 404
-    # means the label was already absent, which is success for an idempotent
-    # remove.
-    repo_conn
-    |> delete!("issues/#{issue_xref}/labels/#{label}")
+  def do_handle_call(:remove_label, {{:raw, token}, repo_xref}, {issue_xref, label}) do
+    # The label is a single path segment, so it must be www-form-encoded: a label
+    # may legitimately contain `/`, `?`, or `#`, none of which `URI.encode`
+    # escapes (they are reserved characters). We can't route this through the
+    # shared `delete!` either — it runs the whole path through `URI.encode`, which
+    # would double-encode the `%` in our escapes — so we build the path directly,
+    # the way `:get_user_by_login` does. A 404 means the label was already absent,
+    # which is success for an idempotent remove.
+    "token #{token}"
+    |> tesla_client()
+    |> Tesla.delete!(
+      "/repositories/#{repo_xref}/issues/#{issue_xref}/labels/#{URI.encode_www_form(label)}"
+    )
     |> case do
       %{status: status} when status in [200, 404] ->
         :ok

--- a/lib/github/github/server.ex
+++ b/lib/github/github/server.ex
@@ -464,6 +464,16 @@ defmodule BorsNG.GitHub.Server do
     end
   end
 
+  def do_handle_call(:list_issues_by_label, {{:raw, token}, repo_xref}, {label}) do
+    {:ok,
+     get_issues_by_label_!(
+       token,
+       "#{site()}/repositories/#{repo_xref}/issues?state=open&per_page=100&labels=" <>
+         URI.encode_www_form(label),
+       []
+     )}
+  end
+
   def do_handle_call(:get_reviews, {{:raw, token}, repo_xref}, {issue_xref, sha}) do
     reviews =
       token
@@ -822,6 +832,45 @@ defmodule BorsNG.GitHub.Server do
     case next_headers do
       [] -> prs
       [next] -> get_open_prs_!(token, next.url, prs)
+    end
+  end
+
+  # Paginate the repo's issues list filtered by label. Returns `{number,
+  # [label_name]}` per issue — the issues endpoint already embeds each item's
+  # full label set, so the backstop sweep gets every PR's current labels in the
+  # same response it uses to discover them, with no extra per-PR read. The
+  # `?labels=` filter is applied server-side, so a repo with thousands of open
+  # PRs still only returns the (few) PRs carrying the label.
+  @spec get_issues_by_label_!(binary, binary | nil, [{integer, [binary]}]) ::
+          [{integer, [binary]}]
+  defp get_issues_by_label_!(_, nil, acc) do
+    acc
+  end
+
+  defp get_issues_by_label_!(token, url, acc) do
+    params = get_url_params(url)
+
+    {raw, headers} =
+      "token #{token}"
+      |> tesla_client(@content_type)
+      |> Tesla.get!(url, query: params)
+      |> case do
+        %{body: raw, status: 200, headers: headers} -> {raw, headers}
+        _ -> {"[]", %{}}
+      end
+
+    acc =
+      raw
+      |> Jason.decode!()
+      |> Enum.map(fn issue ->
+        names = Enum.map(issue["labels"] || [], fn %{"name" => name} -> name end)
+        {issue["number"], names}
+      end)
+      |> Enum.concat(acc)
+
+    case get_next_headers(headers) do
+      [] -> acc
+      [next] -> get_issues_by_label_!(token, next.url, acc)
     end
   end
 

--- a/lib/github/github/server_mock.ex
+++ b/lib/github/github/server_mock.ex
@@ -626,6 +626,22 @@ defmodule BorsNG.GitHub.ServerMock do
     end
   end
 
+  def do_handle_call(:list_issues_by_label, repo_conn, {label}, state) do
+    with {:ok, repo} <- Map.fetch(state, repo_conn) do
+      result =
+        repo
+        |> Map.get(:labels, %{})
+        |> Enum.filter(fn {_issue_xref, names} -> label in (names || []) end)
+        |> Enum.map(fn {issue_xref, names} -> {issue_xref, names} end)
+
+      {{:ok, result}, state}
+    end
+    |> case do
+      {{:ok, _}, _} = res -> res
+      _ -> {{:error, :list_issues_by_label}, state}
+    end
+  end
+
   def do_handle_call(
         :get_reviews,
         repo_conn,

--- a/lib/github/github/server_mock.ex
+++ b/lib/github/github/server_mock.ex
@@ -103,6 +103,7 @@ defmodule BorsNG.GitHub.ServerMock do
           :get_pr_files_error => integer,
           :get_commit_status_error => integer,
           :get_labels_error => integer,
+          :list_issues_by_label_error => boolean,
           :get_reviews_error => integer,
           :post_commit_status_error => integer,
           :post_comment_error => integer
@@ -624,6 +625,15 @@ defmodule BorsNG.GitHub.ServerMock do
       {:ok, state} -> {:ok, state}
       _ -> {{:error, :remove_label}, state}
     end
+  end
+
+  def do_handle_call(
+        :list_issues_by_label,
+        _repo_conn,
+        {_label},
+        %{list_issues_by_label_error: true} = state
+      ) do
+    {{:error, :list_issues_by_label, 502, "Bad Gateway"}, state}
   end
 
   def do_handle_call(:list_issues_by_label, repo_conn, {label}, state) do

--- a/lib/github/github/server_mock.ex
+++ b/lib/github/github/server_mock.ex
@@ -599,6 +599,33 @@ defmodule BorsNG.GitHub.ServerMock do
     end
   end
 
+  def do_handle_call(:add_labels, repo_conn, {issue_xref, new_labels}, state) do
+    with {:ok, repo} <- Map.fetch(state, repo_conn) do
+      labels = Map.get(repo, :labels, %{})
+      existing = labels[issue_xref] || []
+      merged = Enum.uniq(existing ++ new_labels)
+      repo = Map.put(repo, :labels, Map.put(labels, issue_xref, merged))
+      {:ok, %{state | repo_conn => repo}}
+    end
+    |> case do
+      {:ok, state} -> {:ok, state}
+      _ -> {{:error, :add_labels}, state}
+    end
+  end
+
+  def do_handle_call(:remove_label, repo_conn, {issue_xref, label}, state) do
+    with {:ok, repo} <- Map.fetch(state, repo_conn) do
+      labels = Map.get(repo, :labels, %{})
+      remaining = (labels[issue_xref] || []) -- [label]
+      repo = Map.put(repo, :labels, Map.put(labels, issue_xref, remaining))
+      {:ok, %{state | repo_conn => repo}}
+    end
+    |> case do
+      {:ok, state} -> {:ok, state}
+      _ -> {{:error, :remove_label}, state}
+    end
+  end
+
   def do_handle_call(
         :get_reviews,
         repo_conn,

--- a/lib/web/command.ex
+++ b/lib/web/command.ex
@@ -30,6 +30,7 @@ defmodule BorsNG.Command do
   alias BorsNG.Database.User
   alias BorsNG.GitHub
   alias BorsNG.Worker.DelegationInvalidator
+  alias BorsNG.Worker.Labeler
   alias BorsNG.Worker.Syncer
 
   import BorsNG.Router.Helpers
@@ -674,6 +675,8 @@ defmodule BorsNG.Command do
   def run(c, :undelegate) do
     Permission.undelegate_patch(c.patch.id)
 
+    Labeler.reconcile_delegated(c.patch)
+
     Project.ping!(c.project.id)
 
     c.project.repo_xref
@@ -688,6 +691,8 @@ defmodule BorsNG.Command do
     undelegatee = get_or_insert_user_by_login(c, login)
 
     Permission.undelegate(undelegatee.id, c.patch.id)
+
+    Labeler.reconcile_delegated(c.patch)
 
     Project.ping!(c.project.id)
 
@@ -762,6 +767,8 @@ defmodule BorsNG.Command do
         expires_at: expires_at,
         delegated_at_commit: c.patch.commit
       )
+
+      Labeler.reconcile_delegated(conn, toml, c.patch)
 
       Project.ping!(c.project.id)
 

--- a/lib/web/controllers/webhook_controller.ex
+++ b/lib/web/controllers/webhook_controller.ex
@@ -66,6 +66,7 @@ defmodule BorsNG.WebhookController do
   alias BorsNG.Worker.Batcher
   alias BorsNG.Worker.BranchDeleter
   alias BorsNG.Worker.DelegationInvalidator
+  alias BorsNG.Worker.Labeler
   alias BorsNG.Command
   alias BorsNG.Database.Attempt
   alias BorsNG.Database.Batch
@@ -370,6 +371,7 @@ defmodule BorsNG.WebhookController do
       |> Kernel.not()
 
     {delegation_count, _} = Permission.undelegate_patch(patch.id)
+    Labeler.reconcile_delegated(patch)
 
     if had_incomplete_batch do
       batcher = Batcher.Registry.get(project.id)
@@ -419,7 +421,7 @@ defmodule BorsNG.WebhookController do
     |> Command.run()
   end
 
-  def do_webhook_pr(_conn, %{action: "closed", project: project, patch: p}) do
+  def do_webhook_pr(_conn, %{action: "closed", project: project, patch: p, pr: pr}) do
     Project.ping!(project.id)
     Repo.update!(Patch.changeset(p, %{open: false}))
     # Ensure a closed PR is removed from any waiting/running batches and try jobs
@@ -429,6 +431,16 @@ defmodule BorsNG.WebhookController do
     attemptor = Attemptor.Registry.get(project.id)
     Attemptor.cancel(attemptor, p.id)
     BranchDeleter.delete(p)
+
+    # A PR abandoned without merging has no reason to keep its delegations, so
+    # wipe them and take the `delegated` label off. A bors *merge* also arrives
+    # here as a "closed" event, but we deliberately leave a merged PR's
+    # delegations and labels in place as a historical record (the rows expire
+    # and get swept in time; see LIFECYCLE_LABELS.md).
+    unless pr.merged do
+      Permission.undelegate_patch(p.id)
+      Labeler.reconcile_delegated(p)
+    end
   end
 
   def do_webhook_pr(conn, %{action: "reopened", project: project, patch: p}) do

--- a/lib/worker/batcher.ex
+++ b/lib/worker/batcher.ex
@@ -926,12 +926,15 @@ defmodule BorsNG.Worker.Batcher do
     send_zulip(batch, next_status)
 
     if next_status != :running do
-      # The batch has left :running (merged, errored, or conflicted), so its
-      # patches are no longer on the queue. `awaiting-requeue` for a terminal
-      # build failure is set separately in complete_batch(:error); this only
-      # takes `ready-to-merge` / `bors-staging` off.
-      patches = batch.id |> Patch.all_for_batch() |> Repo.all()
-      Labeler.reconcile_queue(repo_conn, batch.into_branch, patches)
+      # A successful merge deliberately leaves the PR's labels untouched: the PR
+      # closes, so `ready-to-merge` / `bors-staging` (and `delegated`) freeze as a
+      # best-effort historical record of how it merged. Only a failure — which
+      # leaves the PR open — reconciles its queue labels off (`awaiting-requeue`
+      # for a terminal build failure is set separately in complete_batch(:error)).
+      if next_status != :ok do
+        patches = batch.id |> Patch.all_for_batch() |> Repo.all()
+        Labeler.reconcile_queue(repo_conn, batch.into_branch, patches)
+      end
 
       poll_(batch.project_id)
     end

--- a/lib/worker/batcher.ex
+++ b/lib/worker/batcher.ex
@@ -26,6 +26,7 @@ defmodule BorsNG.Worker.Batcher do
   alias BorsNG.Database.Context.Delegation
   alias BorsNG.Worker.Batcher
   alias BorsNG.Worker.Batcher.Divider
+  alias BorsNG.Worker.Labeler
   alias BorsNG.Worker.Zulip
   alias BorsNG.Database.Repo
   alias BorsNG.Database.Batch
@@ -212,12 +213,20 @@ defmodule BorsNG.Worker.Batcher do
       |> Batch.all_for_project(:waiting)
       |> Repo.all()
 
-    Enum.each(waiting, &Repo.delete!/1)
-
     running =
       project_id
       |> Batch.all_for_project(:running)
       |> Repo.all()
+
+    # Capture each batch's patches (with its base branch) before mutating —
+    # deleting a waiting batch removes its patch links — so the labels can be
+    # reconciled off the queue at the end.
+    affected =
+      Enum.map(waiting ++ running, fn b ->
+        {b.into_branch, b.id |> Patch.all_for_batch() |> Repo.all()}
+      end)
+
+    Enum.each(waiting, &Repo.delete!/1)
 
     Enum.map(running, &Batch.changeset(&1, %{state: :canceled}))
     |> Enum.each(&Repo.update!/1)
@@ -231,6 +240,10 @@ defmodule BorsNG.Worker.Batcher do
 
     Enum.each(running, &send_status(repo_conn, &1, :canceled))
     Enum.each(waiting, &send_status(repo_conn, &1, :canceled))
+
+    Enum.each(affected, fn {branch, patches} ->
+      Labeler.reconcile_queue(repo_conn, branch, patches)
+    end)
   end
 
   def handle_info({:poll, repetition}, project_id) do
@@ -324,6 +337,11 @@ defmodule BorsNG.Worker.Batcher do
       reviewer: reviewer
     })
     |> Repo.insert!()
+
+    # The patch is now on the queue (a :waiting batch); reflect that in the
+    # labels. This also clears any lingering `awaiting-requeue` from a previous
+    # failed build, since the PR has been put back on the queue.
+    Labeler.reconcile_queue(repo_conn, patch.into_branch, [patch])
 
     Project.ping!(project.id)
 
@@ -497,6 +515,11 @@ defmodule BorsNG.Worker.Batcher do
       |> Repo.update!()
 
       send_zulip(batch, status)
+
+      # Now that the batch state is committed, reflect it in the queue labels:
+      # a `:running` batch is "building", while a failed merge (:conflict /
+      # :error) takes its patches off the queue.
+      Labeler.reconcile_queue(repo_conn, batch.into_branch, Enum.map(patch_links, & &1.patch))
 
       Project.ping!(batch.project_id)
       status
@@ -892,6 +915,13 @@ defmodule BorsNG.Worker.Batcher do
     send_zulip(batch, next_status)
 
     if next_status != :running do
+      # The batch has left :running (merged, errored, or conflicted), so its
+      # patches are no longer on the queue. `awaiting-requeue` for a terminal
+      # build failure is set separately in complete_batch(:error); this only
+      # takes `ready-to-merge` / `bors-staging` off.
+      patches = batch.id |> Patch.all_for_batch() |> Repo.all()
+      Labeler.reconcile_queue(repo_conn, batch.into_branch, patches)
+
       poll_(batch.project_id)
     end
   end
@@ -1004,6 +1034,12 @@ defmodule BorsNG.Worker.Batcher do
 
     if state == :retrying do
       poll_after_delay(project)
+    else
+      # Terminal failure (a single-patch batch): the PR is dropped and needs a
+      # maintainer to put it back on the queue, so flag it. `ready-to-merge` /
+      # `bors-staging` are taken off by maybe_complete_batch once the batch
+      # state is committed to :error.
+      Labeler.mark_awaiting_requeue(repo_conn, batch.into_branch, patches)
     end
 
     send_message(repo_conn, patches, {state, erred})
@@ -1133,6 +1169,10 @@ defmodule BorsNG.Worker.Batcher do
     end
 
     send_status(repo_conn, batch, :canceled)
+
+    # The canceled patch leaves the queue; any uncanceled patches were re-queued
+    # into a fresh batch above, so reconcile reflects both.
+    Labeler.reconcile_queue(repo_conn, batch.into_branch, patches)
   end
 
   defp cancel_patch(batch, patch_id, _state, reason) do
@@ -1150,6 +1190,9 @@ defmodule BorsNG.Worker.Batcher do
     repo_conn = get_repo_conn(project)
     send_status(repo_conn, batch.id, [patch], :canceled)
     send_message(repo_conn, [patch], {:canceled, :failed, reason})
+
+    # The patch has been removed from its (waiting) batch, so it's off the queue.
+    Labeler.reconcile_queue(repo_conn, batch.into_branch, [patch])
   end
 
   defp patch_preflight(repo_conn, patch) do

--- a/lib/worker/batcher.ex
+++ b/lib/worker/batcher.ex
@@ -405,14 +405,17 @@ defmodule BorsNG.Worker.Batcher do
     project = batch.project
     repo_conn = get_repo_conn(project)
 
-    patch_links =
+    {closed_links, patch_links} =
       Repo.all(LinkPatchBatch.from_batch(batch.id))
       |> Enum.sort_by(& &1.patch.pr_xref)
-      |> Enum.reject(fn l ->
-        closed = l.patch.open == false
-        if closed, do: Repo.delete!(l)
-        closed
-      end)
+      |> Enum.split_with(&(&1.patch.open == false))
+
+    Enum.each(closed_links, &Repo.delete!/1)
+
+    # A PR closed while queued has just left the queue; reconcile its labels off.
+    # The closed links are gone now and these patches are dropped from the
+    # reconcile below, so they wouldn't be touched otherwise.
+    Labeler.reconcile_queue(repo_conn, batch.into_branch, Enum.map(closed_links, & &1.patch))
 
     # If all patches were closed and removed, cancel the batch early
     if Enum.empty?(patch_links) do
@@ -764,6 +767,14 @@ defmodule BorsNG.Worker.Batcher do
     state = Divider.split_batch_with_conflicts(patch_links, batch)
     poll_after_delay(project)
 
+    if state == :failed do
+      # A single unmergeable PR is dropped terminally, so flag it for a
+      # maintainer to re-queue. The queue labels (`ready-to-merge` /
+      # `bors-staging`) come off in start_waiting_batch's reconcile once the
+      # batch is committed to :conflict.
+      Labeler.mark_awaiting_requeue(repo_conn, batch.into_branch, patches)
+    end
+
     conflict_msg =
       case state do
         :failed -> {:conflict, :failed, batch.into_branch}
@@ -1011,6 +1022,12 @@ defmodule BorsNG.Worker.Batcher do
           {:push_failed_unknown_failure, batch.into_branch, status_code, raw_error_content}
         )
 
+        # The build passed but the push to the base branch failed unrecoverably
+        # and we don't re-queue, so the PR is dropped and needs a maintainer to
+        # put it back on. `ready-to-merge` / `bors-staging` come off in
+        # maybe_complete_batch once the batch state is committed to :error.
+        Labeler.mark_awaiting_requeue(repo_conn, batch.into_branch, patches)
+
         :error
     end
   end
@@ -1080,6 +1097,7 @@ defmodule BorsNG.Worker.Batcher do
 
   defp timeout_batch(batch) do
     project = batch.project
+    repo_conn = get_repo_conn(project)
 
     patch_links =
       batch.id
@@ -1091,11 +1109,14 @@ defmodule BorsNG.Worker.Batcher do
 
     if state == :retrying do
       poll_after_delay(project)
+    else
+      # Terminal failure (a single-patch batch): the PR is dropped and needs a
+      # maintainer to put it back on the queue, so flag it before the queue
+      # reconcile below takes `ready-to-merge` / `bors-staging` off.
+      Labeler.mark_awaiting_requeue(repo_conn, batch.into_branch, patches)
     end
 
-    project
-    |> get_repo_conn()
-    |> send_message(patches, {:timeout, state})
+    send_message(repo_conn, patches, {:timeout, state})
 
     batch
     |> Batch.changeset(%{state: :error})
@@ -1105,9 +1126,12 @@ defmodule BorsNG.Worker.Batcher do
 
     Project.ping!(project.id)
 
-    project
-    |> get_repo_conn()
-    |> send_status(batch, :timeout)
+    send_status(repo_conn, batch, :timeout)
+
+    # The batch is no longer :running, so its patches are off the queue. A
+    # :retrying bisect re-queued its halves into fresh :waiting batches, which
+    # this reconcile sees and keeps labeled. Mirrors maybe_complete_batch.
+    Labeler.reconcile_queue(repo_conn, batch.into_branch, patches)
   end
 
   defp cancel_patch(nil, _, _), do: :ok

--- a/lib/worker/batcher/bors_toml.ex
+++ b/lib/worker/batcher/bors_toml.ex
@@ -85,6 +85,7 @@ defmodule BorsNG.Worker.Batcher.BorsToml do
           | :delegation_invalidate_on_paths
           | :delegation_restrict_to_paths
           | :labels
+          | :label_names_not_distinct
           | :empty_config
           | :parse_failed
 
@@ -209,11 +210,15 @@ defmodule BorsNG.Worker.Batcher.BorsToml do
           label_delegated: label_delegated
         }
 
-        labels_valid? =
-          Enum.all?(
-            [label_on_queue, label_building, label_failed, label_delegated],
-            &valid_label?/1
-          )
+        label_names = [label_on_queue, label_building, label_failed, label_delegated]
+        labels_valid? = Enum.all?(label_names, &valid_label?/1)
+
+        # Each concern must map to its own label name. Two concerns sharing a name
+        # would make the reconcile contradict itself (one wants the label present,
+        # the other absent), so reject it at parse time. Only the managed (non-nil)
+        # names need to be distinct.
+        managed_names = Enum.reject(label_names, &is_nil/1)
+        labels_distinct? = managed_names == Enum.uniq(managed_names)
 
         case toml do
           %{status: status} when not is_list(status) ->
@@ -244,6 +249,9 @@ defmodule BorsNG.Worker.Batcher.BorsToml do
           # validity test calls valid_label?/1.)
           _ when not labels_valid? ->
             {:error, :labels}
+
+          _ when not labels_distinct? ->
+            {:error, :label_names_not_distinct}
 
           %{status: [], block_labels: [], pr_status: []} ->
             {:error, :empty_config}

--- a/lib/worker/batcher/bors_toml.ex
+++ b/lib/worker/batcher/bors_toml.ex
@@ -34,7 +34,11 @@ defmodule BorsNG.Worker.Batcher.BorsToml do
             max_batch_size: nil,
             delegation_default_expiry_sec: nil,
             delegation_invalidate_on_paths: [],
-            delegation_restrict_to_paths: []
+            delegation_restrict_to_paths: [],
+            label_on_queue: nil,
+            label_building: nil,
+            label_failed: nil,
+            label_delegated: nil
 
   @type tcommitter :: %{
           name: binary,
@@ -59,7 +63,11 @@ defmodule BorsNG.Worker.Batcher.BorsToml do
           max_batch_size: integer | nil,
           delegation_default_expiry_sec: pos_integer() | nil,
           delegation_invalidate_on_paths: [binary],
-          delegation_restrict_to_paths: [binary]
+          delegation_restrict_to_paths: [binary],
+          label_on_queue: binary | nil,
+          label_building: binary | nil,
+          label_failed: binary | nil,
+          label_delegated: binary | nil
         }
 
   @type err ::
@@ -76,6 +84,7 @@ defmodule BorsNG.Worker.Batcher.BorsToml do
           | :delegation_default_expiry_sec
           | :delegation_invalidate_on_paths
           | :delegation_restrict_to_paths
+          | :labels
           | :empty_config
           | :parse_failed
 
@@ -95,6 +104,13 @@ defmodule BorsNG.Worker.Batcher.BorsToml do
   end
 
   defp valid_glob?(_pattern), do: false
+
+  # A managed-label name is either unset (`nil`, the label is not managed) or a
+  # non-empty string. Anything else (a number, a list, the `:invalid` sentinel
+  # for a malformed `[labels]` table) is a configuration error.
+  defp valid_label?(nil), do: true
+  defp valid_label?(label) when is_binary(label), do: label != ""
+  defp valid_label?(_label), do: false
 
   @spec new(binary) :: {:ok, t} | {:error, err}
   def new(str) when is_binary(str) do
@@ -118,6 +134,23 @@ defmodule BorsNG.Worker.Batcher.BorsToml do
             m ->
               {Map.get(m, "default_expiry_sec", nil), Map.get(m, "invalidate_on_paths", []),
                Map.get(m, "restrict_to_paths", [])}
+          end
+
+        labels_table =
+          case Map.get(toml, "labels", nil) do
+            nil -> %{}
+            l when is_map(l) -> to_map(l)
+            _ -> :invalid
+          end
+
+        {label_on_queue, label_building, label_failed, label_delegated} =
+          case labels_table do
+            :invalid ->
+              {:invalid, :invalid, :invalid, :invalid}
+
+            m ->
+              {Map.get(m, "on_queue", nil), Map.get(m, "building", nil),
+               Map.get(m, "failed", nil), Map.get(m, "delegated", nil)}
           end
 
         committer = Map.get(toml, "committer", nil)
@@ -169,7 +202,11 @@ defmodule BorsNG.Worker.Batcher.BorsToml do
           max_batch_size: Map.get(toml, "max_batch_size", nil),
           delegation_default_expiry_sec: delegation_default_expiry_sec,
           delegation_invalidate_on_paths: delegation_invalidate_on_paths,
-          delegation_restrict_to_paths: delegation_restrict_to_paths
+          delegation_restrict_to_paths: delegation_restrict_to_paths,
+          label_on_queue: label_on_queue,
+          label_building: label_building,
+          label_failed: label_failed,
+          label_delegated: label_delegated
         }
 
         case toml do
@@ -247,6 +284,17 @@ defmodule BorsNG.Worker.Batcher.BorsToml do
 
               not Enum.all?(toml.delegation_restrict_to_paths, &valid_glob?/1) ->
                 {:error, :delegation_restrict_to_paths}
+
+              not Enum.all?(
+                [
+                  toml.label_on_queue,
+                  toml.label_building,
+                  toml.label_failed,
+                  toml.label_delegated
+                ],
+                &valid_label?/1
+              ) ->
+                {:error, :labels}
 
               true ->
                 {:ok, %{toml | status: status, pr_status: pr_status}}

--- a/lib/worker/batcher/bors_toml.ex
+++ b/lib/worker/batcher/bors_toml.ex
@@ -209,6 +209,12 @@ defmodule BorsNG.Worker.Batcher.BorsToml do
           label_delegated: label_delegated
         }
 
+        labels_valid? =
+          Enum.all?(
+            [label_on_queue, label_building, label_failed, label_delegated],
+            &valid_label?/1
+          )
+
         case toml do
           %{status: status} when not is_list(status) ->
             {:error, :status}
@@ -231,6 +237,13 @@ defmodule BorsNG.Worker.Batcher.BorsToml do
 
           %{cut_body_after: c} when not is_binary(c) and not is_nil(c) ->
             {:error, :cut_body_after}
+
+          # Checked before :empty_config so a malformed [labels] table reports the
+          # specific :labels error rather than being masked as an empty config when
+          # the toml sets no status/block_labels/pr_status. (Can't be a guard: the
+          # validity test calls valid_label?/1.)
+          _ when not labels_valid? ->
+            {:error, :labels}
 
           %{status: [], block_labels: [], pr_status: []} ->
             {:error, :empty_config}
@@ -284,17 +297,6 @@ defmodule BorsNG.Worker.Batcher.BorsToml do
 
               not Enum.all?(toml.delegation_restrict_to_paths, &valid_glob?/1) ->
                 {:error, :delegation_restrict_to_paths}
-
-              not Enum.all?(
-                [
-                  toml.label_on_queue,
-                  toml.label_building,
-                  toml.label_failed,
-                  toml.label_delegated
-                ],
-                &valid_label?/1
-              ) ->
-                {:error, :labels}
 
               true ->
                 {:ok, %{toml | status: status, pr_status: pr_status}}

--- a/lib/worker/batcher/get_bors_toml.ex
+++ b/lib/worker/batcher/get_bors_toml.ex
@@ -7,10 +7,51 @@ defmodule BorsNG.Worker.Batcher.GetBorsToml do
 
   alias BorsNG.GitHub
   alias BorsNG.Worker.Batcher.BorsToml
+  alias BorsNG.Worker.Batcher.GetBorsToml.Cache
 
   # Beyond :fetch_failed, get/2 delegates to BorsToml.new and passes through any
   # of its validation errors, so the domain is BorsToml.err() | :fetch_failed.
   @type terror :: BorsToml.err() | :fetch_failed
+
+  @doc """
+  Like `get/2`, but memoized per `(repo_xref, branch)` in a short-TTL ETS cache
+  (`Cache`).
+
+  Intended for the *reconcile* paths only — the lifecycle `Labeler` and the
+  delegation sweep, which re-read the same base-branch config many times. The
+  batcher's merge-decision reads must stay on `get/2`: a stale config must never
+  drive a merge.
+
+  Both `{:ok, toml}` and `{:error, _}` are cached, errors with a shorter TTL so
+  a freshly-added `bors.toml` is picked up promptly. A non-positive
+  `:bors_toml_cache_ttl_ms` (the test default) bypasses the cache entirely.
+  """
+  @spec get_cached(GitHub.tconn(), binary) :: {:ok, BorsToml.t()} | {:error, terror}
+  def get_cached({_token, repo_xref} = repo_conn, branch) do
+    ttl = Confex.get_env(:bors, :bors_toml_cache_ttl_ms, 120_000)
+
+    if ttl <= 0 do
+      get(repo_conn, branch)
+    else
+      key = {repo_xref, branch}
+
+      case Cache.fetch(key) do
+        {:ok, value} ->
+          value
+
+        :miss ->
+          value = get(repo_conn, branch)
+          Cache.put(key, value, entry_ttl(value, ttl))
+      end
+    end
+  end
+
+  # Errors get a shorter TTL than successes so a repo that just gained a
+  # `bors.toml` (or fixed a broken one) isn't pinned to the failure for the full
+  # success window.
+  defp entry_ttl({:ok, _}, ttl), do: ttl
+  defp entry_ttl({:error, _}, ttl), do: min(ttl, error_ttl())
+  defp error_ttl, do: Confex.get_env(:bors, :bors_toml_cache_error_ttl_ms, 15_000)
 
   @spec get(GitHub.tconn(), binary) :: {:ok, BorsToml.t()} | {:error, terror}
   def get(repo_conn, branch) do

--- a/lib/worker/batcher/get_bors_toml_cache.ex
+++ b/lib/worker/batcher/get_bors_toml_cache.ex
@@ -1,0 +1,90 @@
+defmodule BorsNG.Worker.Batcher.GetBorsToml.Cache do
+  @moduledoc """
+  Owns the ETS table backing `BorsNG.Worker.Batcher.GetBorsToml.get_cached/2`.
+
+  The cache is a short-TTL projection of `bors.toml` per `(repo_xref, branch)`,
+  used only by the *reconcile* paths (the lifecycle `Labeler` and the delegation
+  sweep) to collapse the repeated base-branch config reads those paths would
+  otherwise make — most acutely the label backstop sweep, which resolves the
+  same handful of base branches for every PR it touches.
+
+  It is deliberately **not** used on the batcher's merge-decision reads, where a
+  stale config could drive an actual merge; those keep calling
+  `GetBorsToml.get/2` directly.
+
+  Entries expire by TTL — checked lazily on read, plus a periodic prune so a
+  multi-tenant keyspace can't grow without bound. The table is public with read
+  concurrency so the batcher casts, the sweep, and the backstop all read without
+  serializing through this process.
+  """
+
+  use GenServer
+
+  @table __MODULE__
+
+  def start_link(_opts \\ []) do
+    GenServer.start_link(__MODULE__, :ok, name: __MODULE__)
+  end
+
+  @doc "The ETS table name (also the owning process name)."
+  def table, do: @table
+
+  @doc """
+  Look up a fresh (non-expired) entry. Returns `{:ok, value}` on a hit or
+  `:miss` otherwise (absent, expired, or table not yet created).
+  """
+  @spec fetch(term) :: {:ok, term} | :miss
+  def fetch(key) do
+    now = now_ms()
+
+    case :ets.lookup(@table, key) do
+      [{^key, value, expires_at}] when expires_at > now -> {:ok, value}
+      _ -> :miss
+    end
+  rescue
+    ArgumentError -> :miss
+  end
+
+  @doc "Store `value` under `key`, expiring `ttl_ms` from now. Returns `value`."
+  @spec put(term, term, non_neg_integer) :: term
+  def put(key, value, ttl_ms) do
+    :ets.insert(@table, {key, value, now_ms() + ttl_ms})
+    value
+  rescue
+    ArgumentError -> value
+  end
+
+  @impl GenServer
+  def init(:ok) do
+    :ets.new(@table, [:named_table, :public, :set, read_concurrency: true])
+    schedule_prune()
+    {:ok, :ok}
+  end
+
+  @impl GenServer
+  def handle_info(:prune, state) do
+    prune()
+    schedule_prune()
+    {:noreply, state}
+  end
+
+  def handle_info(_msg, state), do: {:noreply, state}
+
+  # Drop every entry whose `expires_at` (the 3rd tuple element) is at or before
+  # now. Keys and values are arbitrary terms, so the match spec only constrains
+  # the timestamp.
+  defp prune do
+    now = now_ms()
+    :ets.select_delete(@table, [{{:_, :_, :"$1"}, [{:"=<", :"$1", now}], [true]}])
+  end
+
+  defp schedule_prune do
+    Process.send_after(self(), :prune, prune_period_ms())
+  end
+
+  defp prune_period_ms do
+    Confex.get_env(:bors, :bors_toml_cache_prune_period_ms, 600_000)
+  end
+
+  defp now_ms, do: System.monotonic_time(:millisecond)
+end

--- a/lib/worker/batcher/message.ex
+++ b/lib/worker/batcher/message.ex
@@ -399,6 +399,11 @@ defmodule BorsNG.Worker.Batcher.Message do
     "bors.toml: expected [delegation] restrict_to_paths to be a list of glob patterns"
   end
 
+  def generate_bors_toml_error(:labels) do
+    "bors.toml: expected each [labels] entry (on_queue, building, failed, delegated) " <>
+      "to be a non-empty string"
+  end
+
   # Catch-all so a future validation key can never crash the renderer (and the
   # batcher with it) the way the unhandled keys above silently did. Prefer an
   # explicit clause with friendly wording over relying on this.

--- a/lib/worker/batcher/message.ex
+++ b/lib/worker/batcher/message.ex
@@ -404,6 +404,11 @@ defmodule BorsNG.Worker.Batcher.Message do
       "to be a non-empty string"
   end
 
+  def generate_bors_toml_error(:label_names_not_distinct) do
+    "bors.toml: each [labels] entry (on_queue, building, failed, delegated) " <>
+      "must use a distinct label name"
+  end
+
   # Catch-all so a future validation key can never crash the renderer (and the
   # batcher with it) the way the unhandled keys above silently did. Prefer an
   # explicit clause with friendly wording over relying on this.

--- a/lib/worker/delegation_invalidator.ex
+++ b/lib/worker/delegation_invalidator.ex
@@ -33,6 +33,7 @@ defmodule BorsNG.Worker.DelegationInvalidator do
   alias BorsNG.Database.UserPatchDelegation
   alias BorsNG.GitHub
   alias BorsNG.Worker.Batcher.GetBorsToml
+  alias BorsNG.Worker.Labeler
 
   require Logger
 
@@ -79,7 +80,7 @@ defmodule BorsNG.Worker.DelegationInvalidator do
            restrict = toml.delegation_restrict_to_paths,
            deny = toml.delegation_invalidate_on_paths,
            true <- restrict != [] or deny != [] do
-        do_invalidate(conn, patch, restrict, deny, delegations)
+        do_invalidate(conn, toml, patch, restrict, deny, delegations)
       else
         _ -> :ok
       end
@@ -94,7 +95,7 @@ defmodule BorsNG.Worker.DelegationInvalidator do
     |> Repo.all()
   end
 
-  defp do_invalidate(conn, patch, restrict, deny, delegations) do
+  defp do_invalidate(conn, toml, patch, restrict, deny, delegations) do
     # pr_diff is the same base...head diff for every delegation; fetch it once.
     # On synchronize a push always happened, so a delta worth filtering exists.
     filter = pr_diff_filter(conn, patch)
@@ -115,6 +116,7 @@ defmodule BorsNG.Worker.DelegationInvalidator do
       ids = Enum.map(revoked, fn {d, _reason} -> d.id end)
       Repo.delete_all(from(d in UserPatchDelegation, where: d.id in ^ids))
       post_revoke_comment(conn, patch, revoked)
+      Labeler.reconcile_delegated(conn, toml, patch)
     end
 
     :ok
@@ -151,7 +153,7 @@ defmodule BorsNG.Worker.DelegationInvalidator do
                restrict = toml.delegation_restrict_to_paths,
                deny = toml.delegation_invalidate_on_paths,
                true <- restrict != [] or deny != [] do
-            decide_merge(conn, patch, restrict, deny, delegations)
+            decide_merge(conn, toml, patch, restrict, deny, delegations)
           else
             _ -> :ok
           end
@@ -159,7 +161,7 @@ defmodule BorsNG.Worker.DelegationInvalidator do
     end
   end
 
-  defp decide_merge(conn, patch, restrict, deny, delegations) do
+  defp decide_merge(conn, toml, patch, restrict, deny, delegations) do
     # Lazy + computed at most once: a (user, patch) delegation is unique, and an
     # empty delta short-circuits before the filter is ever forced.
     filter_fun = fn -> pr_diff_filter(conn, patch) end
@@ -172,6 +174,7 @@ defmodule BorsNG.Worker.DelegationInvalidator do
         {:revoke, reason} ->
           Repo.delete_all(from(x in UserPatchDelegation, where: x.id == ^d.id))
           post_revoke_comment(conn, patch, [{d, reason}])
+          Labeler.reconcile_delegated(conn, toml, patch)
           {:halt, :deny}
 
         # Couldn't read the delta: don't delete (we can't prove it's bad), but

--- a/lib/worker/label_backstop_timer.ex
+++ b/lib/worker/label_backstop_timer.ex
@@ -1,0 +1,60 @@
+defmodule BorsNG.Worker.LabelBackstopTimer do
+  @moduledoc """
+  Periodically runs `BorsNG.Worker.Labeler.backstop_sweep/0`, the self-healing
+  reconcile of the state-derived lifecycle labels (LIFECYCLE_LABELS.md).
+
+  The live per-event reconciles — in the batcher transitions and the delegation
+  sweep — keep labels accurate in the normal case. This timer is the backstop
+  for drift they can't catch: a best-effort label write that was dropped at
+  event time, a restart mid-transition, or a human editing a managed label. It
+  runs on its own (longer) period rather than piggybacking the delegation sweep,
+  so repo-wide label listing stays decoupled from delegation expiry.
+
+  Like the other workers it assumes a single instance (see
+  `BorsNG.Worker.Batcher.Registry`); running multiple nodes would duplicate the
+  reconcile work.
+
+  In the test environment the timer starts but does not schedule itself, so
+  tests drive `Labeler.backstop_sweep/0` directly.
+  """
+
+  use GenServer
+
+  alias BorsNG.Worker.Labeler
+
+  require Logger
+
+  @name BorsNG.Worker.LabelBackstopTimer
+
+  def start_link(_opts \\ []) do
+    GenServer.start_link(__MODULE__, :ok, name: @name)
+  end
+
+  def init(:ok) do
+    unless Application.get_env(:bors, :is_test, false) do
+      schedule_tick()
+    end
+
+    {:ok, :ok}
+  end
+
+  def handle_info(:tick, state) do
+    try do
+      Labeler.backstop_sweep()
+    rescue
+      e ->
+        Logger.error("LabelBackstopTimer sweep failed: #{Exception.message(e)}")
+    end
+
+    schedule_tick()
+    {:noreply, state}
+  end
+
+  def handle_info(_msg, state) do
+    {:noreply, state}
+  end
+
+  defp schedule_tick do
+    Process.send_after(self(), :tick, Confex.fetch_env!(:bors, :label_backstop_period))
+  end
+end

--- a/lib/worker/labeler.ex
+++ b/lib/worker/labeler.ex
@@ -120,14 +120,10 @@ defmodule BorsNG.Worker.Labeler do
   # several batches over its life (e.g. a failed batch plus a fresh re-queue), so
   # we look at all of them: "on the queue" is true if *any* is live.
   defp batch_states_for_patch(patch_id) do
-    Repo.all(
-      from(l in LinkPatchBatch,
-        join: b in Batch,
-        on: b.id == l.batch_id,
-        where: l.patch_id == ^patch_id,
-        select: b.state
-      )
-    )
+    patch_id
+    |> Batch.all_for_patch()
+    |> Repo.all()
+    |> Enum.map(& &1.state)
   end
 
   defp with_toml(repo_conn, branch, fun) do

--- a/lib/worker/labeler.ex
+++ b/lib/worker/labeler.ex
@@ -84,6 +84,8 @@ defmodule BorsNG.Worker.Labeler do
   cleared in the same pass — being queued again is exactly the signal that it no
   longer needs a maintainer to re-queue it.
   """
+  def reconcile_queue(_repo_conn, _branch, []), do: :ok
+
   def reconcile_queue(repo_conn, branch, patches) when is_list(patches) do
     with_toml(repo_conn, branch, fn toml ->
       Enum.each(patches, fn patch ->
@@ -104,6 +106,8 @@ defmodule BorsNG.Worker.Labeler do
   queue. Reads `bors.toml` once from `branch`. The label is cleared later by
   `reconcile_queue/3` when the PR is put back on the queue.
   """
+  def mark_awaiting_requeue(_repo_conn, _branch, []), do: :ok
+
   def mark_awaiting_requeue(repo_conn, branch, patches) when is_list(patches) do
     with_toml(repo_conn, branch, fn toml ->
       Enum.each(patches, fn patch ->

--- a/lib/worker/labeler.ex
+++ b/lib/worker/labeler.ex
@@ -130,9 +130,12 @@ defmodule BorsNG.Worker.Labeler do
     * **Open PRs only.** A merged PR's labels are frozen as history
       (LIFECYCLE_LABELS.md): the discovery query asks for `state=open`, and the
       sweep only ever touches patches whose `patch.open` is true.
-    * **State-derived labels only.** The event-driven `failed`/`awaiting-requeue`
-      label has no current-state definition, so it is never reconciled here; its
-      clear-on-requeue stays with the live `reconcile_queue/3`.
+    * **State-derived labels, plus a one-way `awaiting-requeue` clear.** The
+      three state-derived labels are reconciled in both directions. The
+      event-driven `failed`/`awaiting-requeue` label has no current-state
+      definition, so it is never *added* here and is *removed* only when the PR
+      is back on the queue (mirroring the live `reconcile_queue/3`); a stale
+      `awaiting-requeue` off the queue is undecidable, so it is left alone.
     * **Each PR under its own base branch's config.** A label is reconciled only
       if the PR's *current* `into_branch` config manages that name — preserving
       the "never touch foreign labels" guarantee and the documented

--- a/lib/worker/labeler.ex
+++ b/lib/worker/labeler.ex
@@ -1,0 +1,167 @@
+defmodule BorsNG.Worker.Labeler do
+  @moduledoc """
+  Projects bors's own state onto GitHub PR labels.
+
+  Label management is opt-in per project via the `[labels]` table in
+  `bors.toml` (parsed onto `BorsNG.Worker.Batcher.BorsToml`). When a label name
+  is unset, the corresponding concern is unmanaged and every call here is a
+  no-op, so projects that don't configure `[labels]` see no behavior change.
+
+  Labels are **best-effort projections**: a failed GitHub call is logged and
+  dropped, never raised, so it can't crash a batcher cast or the delegation
+  sweep. The state-derived labels (`delegated`, `on_queue`, `building`) are
+  reconciled toward the database, so a missed update self-corrects the next time
+  the relevant event fires. `awaiting-requeue` (the `failed` label) cannot be
+  derived from current state — a dropped PR looks just like one that was never
+  approved — so it is set and cleared by event instead.
+
+  See LIFECYCLE_LABELS.md for the full design.
+  """
+
+  use BorsNG.Database.Context
+
+  alias BorsNG.Database.Context.Permission
+  alias BorsNG.GitHub
+  alias BorsNG.Worker.Batcher.GetBorsToml
+
+  require Logger
+
+  @doc """
+  Reconcile a single managed label on a PR to `present?`.
+
+  `label` is the configured label name, or `nil` when the concern is unmanaged
+  (a no-op). Idempotent and best-effort: adding a present label or removing an
+  absent one is harmless, and any API error is logged and swallowed.
+  """
+  @spec reconcile(term, term, binary | nil, boolean) :: :ok
+  def reconcile(_conn, _pr_xref, nil, _present?), do: :ok
+
+  def reconcile(conn, pr_xref, label, true) when is_binary(label) do
+    case GitHub.add_labels(conn, pr_xref, [label]) do
+      :ok -> :ok
+      err -> warn("add", label, pr_xref, err)
+    end
+  end
+
+  def reconcile(conn, pr_xref, label, false) when is_binary(label) do
+    case GitHub.remove_label(conn, pr_xref, label) do
+      :ok -> :ok
+      err -> warn("remove", label, pr_xref, err)
+    end
+  end
+
+  @doc """
+  Reconcile the `delegated` label for `patch` against whether it currently has
+  any active (non-expired) delegation. Use this arity when the caller already
+  holds the repo connection and parsed `bors.toml`.
+  """
+  def reconcile_delegated(_conn, nil, %Patch{}), do: :ok
+
+  def reconcile_delegated(conn, toml, %Patch{} = patch) do
+    present? = Permission.patch_has_active_delegation?(patch.id)
+    reconcile(conn, patch.pr_xref, toml.label_delegated, present?)
+  end
+
+  @doc """
+  Reconcile the `delegated` label for `patch`, loading the repo connection and
+  `bors.toml` itself. Use this from sites that don't already hold them (e.g. the
+  delegation sweep). A missing project or unreadable `bors.toml` is a no-op.
+  """
+  def reconcile_delegated(%Patch{} = patch) do
+    with_conn_and_toml(patch, fn conn, toml ->
+      reconcile_delegated(conn, toml, patch)
+    end)
+  end
+
+  @doc """
+  Reconcile the queue labels (`on_queue`, `building`) for `patches`, reading
+  `bors.toml` once from `branch`. A patch is "on the queue" if it is linked to a
+  batch in `:waiting` or `:running`, and "building" if any such batch is
+  `:running`. Both are pure functions of current state, so this is safe to call
+  at any transition and is self-correcting.
+
+  When a patch is back on the queue, the event-driven `awaiting-requeue` label is
+  cleared in the same pass — being queued again is exactly the signal that it no
+  longer needs a maintainer to re-queue it.
+  """
+  def reconcile_queue(repo_conn, branch, patches) when is_list(patches) do
+    with_toml(repo_conn, branch, fn toml ->
+      Enum.each(patches, fn patch ->
+        states = batch_states_for_patch(patch.id)
+        on_queue? = Enum.any?(states, &(&1 in [:waiting, :running]))
+        building? = :running in states
+
+        reconcile(repo_conn, patch.pr_xref, toml.label_on_queue, on_queue?)
+        reconcile(repo_conn, patch.pr_xref, toml.label_building, building?)
+        if on_queue?, do: reconcile(repo_conn, patch.pr_xref, toml.label_failed, false)
+      end)
+    end)
+  end
+
+  @doc """
+  Set the event-driven `awaiting-requeue` (`failed`) label on `patches` — PRs
+  that were approved but whose build failed terminally and were dropped from the
+  queue. Reads `bors.toml` once from `branch`. The label is cleared later by
+  `reconcile_queue/3` when the PR is put back on the queue.
+  """
+  def mark_awaiting_requeue(repo_conn, branch, patches) when is_list(patches) do
+    with_toml(repo_conn, branch, fn toml ->
+      Enum.each(patches, fn patch ->
+        reconcile(repo_conn, patch.pr_xref, toml.label_failed, true)
+      end)
+    end)
+  end
+
+  # The batch states this patch is currently linked to. A patch can be linked to
+  # several batches over its life (e.g. a failed batch plus a fresh re-queue), so
+  # we look at all of them: "on the queue" is true if *any* is live.
+  defp batch_states_for_patch(patch_id) do
+    Repo.all(
+      from(l in LinkPatchBatch,
+        join: b in Batch,
+        on: b.id == l.batch_id,
+        where: l.patch_id == ^patch_id,
+        select: b.state
+      )
+    )
+  end
+
+  defp with_toml(repo_conn, branch, fun) do
+    case GetBorsToml.get(repo_conn, branch) do
+      {:ok, toml} -> fun.(toml)
+      {:error, _} -> :ok
+    end
+  rescue
+    e ->
+      Logger.warning("Labeler: queue reconcile failed: #{Exception.message(e)}")
+      :ok
+  end
+
+  defp with_conn_and_toml(%Patch{} = patch, fun) do
+    project = Repo.get(Project, patch.project_id)
+
+    if project do
+      conn = Project.installation_connection(project.repo_xref, Repo)
+
+      case GetBorsToml.get(conn, patch.into_branch) do
+        {:ok, toml} -> fun.(conn, toml)
+        {:error, _} -> :ok
+      end
+    else
+      :ok
+    end
+  rescue
+    e ->
+      Logger.warning("Labeler: reconcile failed for patch ##{patch.id}: #{Exception.message(e)}")
+
+      :ok
+  end
+
+  defp warn(op, label, pr_xref, err) do
+    Logger.warning(
+      "Labeler: failed to #{op} label #{inspect(label)} on PR ##{pr_xref}: #{inspect(err)}"
+    )
+
+    :ok
+  end
+end

--- a/lib/worker/labeler.ex
+++ b/lib/worker/labeler.ex
@@ -116,6 +116,257 @@ defmodule BorsNG.Worker.Labeler do
     end)
   end
 
+  @doc """
+  Backstop reconcile of the state-derived lifecycle labels (`on_queue`,
+  `building`, `delegated`) across every project with open patches.
+
+  This is the self-healing pass for drift the per-event reconciles can't catch:
+  a best-effort label write that was dropped at event time, a restart
+  mid-transition, or a human manually editing a managed label. It runs off the
+  live path, on `BorsNG.Worker.LabelBackstopTimer`.
+
+  Coverage is deliberately bounded:
+
+    * **Open PRs only.** A merged PR's labels are frozen as history
+      (LIFECYCLE_LABELS.md): the discovery query asks for `state=open`, and the
+      sweep only ever touches patches whose `patch.open` is true.
+    * **State-derived labels only.** The event-driven `failed`/`awaiting-requeue`
+      label has no current-state definition, so it is never reconciled here; its
+      clear-on-requeue stays with the live `reconcile_queue/3`.
+    * **Each PR under its own base branch's config.** A label is reconciled only
+      if the PR's *current* `into_branch` config manages that name — preserving
+      the "never touch foreign labels" guarantee and the documented
+      divergent-name retarget limitation.
+
+  The sweep is diff-based. It discovers candidate PRs with
+  `GitHub.list_issues_by_label/2`, whose response already carries each PR's full
+  label set, so a tick with no drift performs zero writes. A second pass closes
+  the one gap discovery-by-label can't see — a PR that should carry a label but
+  has lost *all* its managed labels (so appears in no listing) — by adding the
+  missing label to the (small) set of patches the DB says should be labeled.
+
+  Config reads go through the short-TTL cache, and a per-project failure is
+  logged and skipped so one bad installation can't abort the whole sweep.
+  """
+  @spec backstop_sweep() :: :ok
+  def backstop_sweep do
+    Repo.all(from(p in Patch, where: p.open, distinct: true, select: p.project_id))
+    |> Enum.each(&backstop_project/1)
+  end
+
+  defp backstop_project(project_id) do
+    project = Repo.get(Project, project_id)
+
+    if project do
+      conn = Project.installation_connection(project.repo_xref, Repo)
+      tomls = open_branch_tomls(conn, project_id)
+
+      case managed_state_names(tomls) do
+        [] ->
+          :ok
+
+        managed ->
+          seen = discover(conn, managed)
+          writes = reconcile_seen(conn, project_id, tomls, seen, 0)
+          reconcile_add_gap(conn, project_id, tomls, seen, writes)
+          :ok
+      end
+    else
+      :ok
+    end
+  rescue
+    e ->
+      Logger.warning(
+        "Labeler: backstop sweep failed for project ##{project_id}: #{Exception.message(e)}"
+      )
+
+      :ok
+  end
+
+  # Read (cached) the bors.toml for every base branch that has an open patch in
+  # this project, returning %{branch => {:ok, toml} | {:error, _}}. A patch's
+  # into_branch is always among these keys, so per-patch lookups never miss.
+  defp open_branch_tomls(conn, project_id) do
+    Repo.all(
+      from(p in Patch,
+        where: p.open and p.project_id == ^project_id,
+        distinct: true,
+        select: p.into_branch
+      )
+    )
+    |> Map.new(fn branch -> {branch, GetBorsToml.get_cached(conn, branch)} end)
+  end
+
+  # The distinct configured names for the three state-derived concerns, across
+  # all of the project's base branches. `failed` is intentionally excluded — it
+  # is event-driven and not reconciled by this sweep.
+  defp managed_state_names(tomls) do
+    tomls
+    |> Map.values()
+    |> Enum.flat_map(fn
+      {:ok, toml} -> [toml.label_on_queue, toml.label_building, toml.label_delegated]
+      {:error, _} -> []
+    end)
+    |> Enum.reject(&is_nil/1)
+    |> Enum.uniq()
+  end
+
+  # Discover PRs carrying any managed name. Returns %{pr_xref => current label
+  # names}; the listing embeds each PR's full label set, so whichever name
+  # surfaces a PR, we get its complete current labels for the diff.
+  defp discover(conn, managed) do
+    Enum.reduce(managed, %{}, fn name, acc ->
+      case GitHub.list_issues_by_label(conn, name) do
+        {:ok, issues} ->
+          Enum.reduce(issues, acc, fn {number, names}, acc -> Map.put(acc, number, names) end)
+
+        _ ->
+          acc
+      end
+    end)
+  end
+
+  # Pass A: for every discovered PR that maps to an open patch in this project,
+  # diff its current labels against bors's state and write only the difference.
+  defp reconcile_seen(_conn, _project_id, _tomls, seen, writes) when map_size(seen) == 0 do
+    writes
+  end
+
+  defp reconcile_seen(conn, project_id, tomls, seen, writes) do
+    xrefs = Map.keys(seen)
+
+    Repo.all(
+      from(p in Patch,
+        where: p.open and p.project_id == ^project_id and p.pr_xref in ^xrefs
+      )
+    )
+    |> Enum.reduce(writes, fn patch, writes ->
+      case tomls[patch.into_branch] do
+        {:ok, toml} -> apply_diff(conn, toml, patch, Map.get(seen, patch.pr_xref, []), writes)
+        _ -> writes
+      end
+    end)
+  end
+
+  # Pass B: the missing-add backstop. Patches the DB says should carry a label
+  # but that appeared in no listing have lost *all* their managed labels; add
+  # what they're due. Patches that appeared in a listing are already handled by
+  # pass A (it adds any managed label they're individually missing), so they are
+  # filtered out here. In steady state this set is empty and writes nothing.
+  defp reconcile_add_gap(conn, project_id, tomls, seen, writes) do
+    project_id
+    |> desired_patches()
+    |> Enum.reject(fn patch -> Map.has_key?(seen, patch.pr_xref) end)
+    |> Enum.reduce(writes, fn patch, writes ->
+      case tomls[patch.into_branch] do
+        {:ok, toml} -> apply_diff(conn, toml, patch, [], writes)
+        _ -> writes
+      end
+    end)
+  end
+
+  # Open patches this project should label: any with an active delegation, plus
+  # any linked to a waiting/running batch. Small (the queued + delegated sets),
+  # so scanning it every sweep is cheap.
+  defp desired_patches(project_id) do
+    now = NaiveDateTime.utc_now() |> NaiveDateTime.truncate(:second)
+
+    delegated =
+      Repo.all(
+        from(p in Patch,
+          join: d in UserPatchDelegation,
+          on: d.patch_id == p.id,
+          where:
+            p.open and p.project_id == ^project_id and
+              (is_nil(d.expires_at) or d.expires_at > ^now),
+          distinct: true
+        )
+      )
+
+    queued =
+      Repo.all(
+        from(p in Patch,
+          join: l in LinkPatchBatch,
+          on: l.patch_id == p.id,
+          join: b in Batch,
+          on: b.id == l.batch_id,
+          where:
+            p.open and p.project_id == ^project_id and
+              (b.state == ^:waiting or b.state == ^:running),
+          distinct: true
+        )
+      )
+
+    Enum.uniq_by(delegated ++ queued, & &1.id)
+  end
+
+  # Compute and apply the label diff for one patch, returning the running count
+  # of PRs written (so writes can be paced without sleeping for the no-op
+  # majority). `current` is the PR's present label names (empty for pass B).
+  defp apply_diff(conn, toml, patch, current, writes) do
+    {to_add, to_remove} = compute_diff(toml, patch, current)
+
+    if to_add == [] and to_remove == [] do
+      writes
+    else
+      pace_write(writes)
+
+      case GitHub.add_labels(conn, patch.pr_xref, to_add) do
+        :ok -> :ok
+        err -> warn("add", to_add, patch.pr_xref, err)
+      end
+
+      Enum.each(to_remove, &reconcile(conn, patch.pr_xref, &1, false))
+      writes + 1
+    end
+  end
+
+  # The {to_add, to_remove} diff for the labels this branch manages, given the
+  # PR's current label names. Unmanaged concerns (nil name) are skipped, so
+  # foreign labels are never touched.
+  defp compute_diff(toml, patch, current) do
+    states = batch_states_for_patch(patch.id)
+    on_queue? = Enum.any?(states, &(&1 in [:waiting, :running]))
+
+    concerns = [
+      {toml.label_delegated, Permission.patch_has_active_delegation?(patch.id)},
+      {toml.label_on_queue, on_queue?},
+      {toml.label_building, :running in states}
+    ]
+
+    {add, remove} =
+      Enum.reduce(concerns, {[], []}, fn
+        {nil, _present?}, acc ->
+          acc
+
+        {label, present?}, {add, remove} ->
+          has? = label in current
+
+          cond do
+            present? and not has? -> {[label | add], remove}
+            not present? and has? -> {add, [label | remove]}
+            true -> {add, remove}
+          end
+      end)
+
+    {add, maybe_clear_failed(toml, on_queue?, current, remove)}
+  end
+
+  # `awaiting-requeue` (the `failed` label) is asymmetric: the sweep can never
+  # *add* it (its set-condition isn't derivable from current state — a dropped PR
+  # looks like one never approved), and it can only safely *clear* it in one
+  # direction — when the PR is back on the queue, mirroring the live
+  # `reconcile_queue/3`. A PR carrying it while *not* queued is left alone:
+  # current state can't tell a genuine awaiting-requeue from a missed `r-`/close
+  # clear. So this only ever removes, and only when on the queue.
+  defp maybe_clear_failed(toml, on_queue?, current, remove) do
+    if not is_nil(toml.label_failed) and on_queue? and toml.label_failed in current do
+      [toml.label_failed | remove]
+    else
+      remove
+    end
+  end
+
   # The batch states this patch is currently linked to. A patch can be linked to
   # several batches over its life (e.g. a failed batch plus a fresh re-queue), so
   # we look at all of them: "on the queue" is true if *any* is live.
@@ -126,8 +377,31 @@ defmodule BorsNG.Worker.Labeler do
     |> Enum.map(& &1.state)
   end
 
+  @doc """
+  Throttle a sequence of label writes so a burst — a sweep, or many delegations
+  expiring in one tick — doesn't trip GitHub's secondary rate limit for
+  mutations. Indexed like the delegation sweep's comment pacing (the first write
+  is free), but much lighter: a label write is a cheap, idempotent best-effort
+  projection, so it doesn't deserve the ~750ms content-creation budget that
+  comments use. A no-op in the test environment.
+  """
+  @spec pace_write(non_neg_integer) :: :ok
+  def pace_write(0), do: :ok
+
+  def pace_write(_idx) do
+    unless Application.get_env(:bors, :is_test, false) do
+      Process.sleep(Confex.get_env(:bors, :label_write_pace_ms, 250))
+    end
+
+    :ok
+  end
+
+  # Reconcile paths read config through the short-TTL cache (GetBorsToml.Cache),
+  # not get/2: a slightly stale label config only affects a best-effort label,
+  # never a merge decision, and the cache collapses the repeated base-branch
+  # reads the sweep and backstop would otherwise make.
   defp with_toml(repo_conn, branch, fun) do
-    case GetBorsToml.get(repo_conn, branch) do
+    case GetBorsToml.get_cached(repo_conn, branch) do
       {:ok, toml} -> fun.(toml)
       {:error, _} -> :ok
     end
@@ -138,12 +412,18 @@ defmodule BorsNG.Worker.Labeler do
   end
 
   defp with_conn_and_toml(%Patch{} = patch, fun) do
-    project = Repo.get(Project, patch.project_id)
+    # Use the project already preloaded by the caller (the delegation sweep
+    # preloads `patch: :project`); only hit the DB when it isn't loaded.
+    project =
+      case patch.project do
+        %Project{} = project -> project
+        _ -> Repo.get(Project, patch.project_id)
+      end
 
     if project do
       conn = Project.installation_connection(project.repo_xref, Repo)
 
-      case GetBorsToml.get(conn, patch.into_branch) do
+      case GetBorsToml.get_cached(conn, patch.into_branch) do
         {:ok, toml} -> fun.(conn, toml)
         {:error, _} -> :ok
       end

--- a/test/batcher/batcher_test.exs
+++ b/test/batcher/batcher_test.exs
@@ -33,6 +33,11 @@ defmodule BorsNG.Worker.BatcherTest do
     {:ok, inst: inst, proj: proj}
   end
 
+  defp labels_for(pr) do
+    GitHub.ServerMock.get_state()
+    |> get_in([{{:installation, 91}, 14}, :labels, pr]) || []
+  end
+
   test "cancel all", %{proj: proj} do
     patch =
       %Patch{
@@ -2116,6 +2121,162 @@ defmodule BorsNG.Worker.BatcherTest do
                files: %{}
              }
            }
+  end
+
+  test "queue labels: r+ adds ready-to-merge, running adds bors-staging, merge clears both",
+       %{proj: proj} do
+    labels_toml = ~s"""
+    status = [ "ci" ]
+    [labels]
+    on_queue = "ready-to-merge"
+    building = "bors-staging"
+    failed = "awaiting-requeue"
+    """
+
+    GitHub.ServerMock.put_state(%{
+      {{:installation, 91}, 14} => %{
+        branches: %{"master" => "ini", "staging" => "", "staging.tmp" => ""},
+        commits: %{},
+        comments: %{1 => []},
+        statuses: %{"iniN" => %{}},
+        # bors.toml on staging.tmp drives the batcher's CI config; on master it
+        # drives the label reconcile (read from the PR's into_branch).
+        files: %{
+          "staging.tmp" => %{"bors.toml" => labels_toml},
+          "master" => %{"bors.toml" => labels_toml}
+        },
+        pulls: %{
+          1 => %Pr{
+            number: 1,
+            title: "Test",
+            body: "Mess",
+            state: :open,
+            base_ref: "master",
+            head_sha: "N",
+            head_ref: "update",
+            base_repo_id: 14,
+            head_repo_id: 14,
+            merged: false
+          }
+        },
+        pr_commits: %{
+          1 => [%GitHub.Commit{sha: "1234", author_name: "a", author_email: "e"}]
+        }
+      }
+    })
+
+    patch =
+      %Patch{project_id: proj.id, pr_xref: 1, commit: "N", into_branch: "master"}
+      |> Repo.insert!()
+
+    # r+ : the PR is now queued (waiting), so it's "ready-to-merge" but not yet
+    # building.
+    Batcher.handle_cast({:reviewed, patch.id, "rvr"}, proj.id)
+    assert "ready-to-merge" in labels_for(1)
+    refute "bors-staging" in labels_for(1)
+
+    # Kick the waiting batch into running.
+    Repo.get_by!(Batch, project_id: proj.id)
+    |> Batch.changeset(%{last_polled: 0})
+    |> Repo.update!()
+
+    Batcher.handle_info({:poll, :once}, proj.id)
+    assert Repo.get_by!(Batch, project_id: proj.id).state == :running
+    assert "ready-to-merge" in labels_for(1)
+    assert "bors-staging" in labels_for(1)
+
+    # CI passes on the staging merge commit; the batch merges and the queue
+    # labels come off.
+    GitHub.ServerMock.put_state(
+      update_in(
+        GitHub.ServerMock.get_state(),
+        [{{:installation, 91}, 14}, :statuses, "iniN"],
+        &Map.put(&1 || %{}, "ci", :ok)
+      )
+    )
+
+    Repo.get_by!(Batch, project_id: proj.id)
+    |> Batch.changeset(%{last_polled: 0})
+    |> Repo.update!()
+
+    Batcher.handle_info({:poll, :once}, proj.id)
+    assert Repo.get_by!(Batch, project_id: proj.id).state == :ok
+    refute "ready-to-merge" in labels_for(1)
+    refute "bors-staging" in labels_for(1)
+  end
+
+  test "queue labels: a terminal build failure flags awaiting-requeue", %{proj: proj} do
+    labels_toml = ~s"""
+    status = [ "ci" ]
+    [labels]
+    on_queue = "ready-to-merge"
+    building = "bors-staging"
+    failed = "awaiting-requeue"
+    """
+
+    GitHub.ServerMock.put_state(%{
+      {{:installation, 91}, 14} => %{
+        branches: %{"master" => "ini", "staging" => "", "staging.tmp" => ""},
+        commits: %{},
+        comments: %{1 => []},
+        statuses: %{"iniN" => %{}},
+        files: %{
+          "staging.tmp" => %{"bors.toml" => labels_toml},
+          "master" => %{"bors.toml" => labels_toml}
+        },
+        pulls: %{
+          1 => %Pr{
+            number: 1,
+            title: "Test",
+            body: "Mess",
+            state: :open,
+            base_ref: "master",
+            head_sha: "N",
+            head_ref: "update",
+            base_repo_id: 14,
+            head_repo_id: 14,
+            merged: false
+          }
+        },
+        pr_commits: %{
+          1 => [%GitHub.Commit{sha: "1234", author_name: "a", author_email: "e"}]
+        }
+      }
+    })
+
+    patch =
+      %Patch{project_id: proj.id, pr_xref: 1, commit: "N", into_branch: "master"}
+      |> Repo.insert!()
+
+    Batcher.handle_cast({:reviewed, patch.id, "rvr"}, proj.id)
+
+    Repo.get_by!(Batch, project_id: proj.id)
+    |> Batch.changeset(%{last_polled: 0})
+    |> Repo.update!()
+
+    Batcher.handle_info({:poll, :once}, proj.id)
+    assert Repo.get_by!(Batch, project_id: proj.id).state == :running
+
+    # CI fails on the staging merge commit: the single-patch batch fails
+    # terminally, so the PR is flagged for a maintainer to re-queue.
+    GitHub.ServerMock.put_state(
+      update_in(
+        GitHub.ServerMock.get_state(),
+        [{{:installation, 91}, 14}, :statuses, "iniN"],
+        &Map.put(&1 || %{}, "ci", :error)
+      )
+    )
+
+    Repo.get_by!(Batch, project_id: proj.id)
+    |> Batch.changeset(%{last_polled: 0})
+    |> Repo.update!()
+
+    Batcher.handle_info({:poll, :once}, proj.id)
+    assert Repo.get_by!(Batch, project_id: proj.id).state == :error
+
+    assert "awaiting-requeue" in labels_for(1)
+    refute "ready-to-merge" in labels_for(1)
+    refute "bors-staging" in labels_for(1)
   end
 
   test "full runthrough (with zero patches)", %{proj: proj} do

--- a/test/batcher/batcher_test.exs
+++ b/test/batcher/batcher_test.exs
@@ -2123,7 +2123,7 @@ defmodule BorsNG.Worker.BatcherTest do
            }
   end
 
-  test "queue labels: r+ adds ready-to-merge, running adds bors-staging, merge clears both",
+  test "queue labels: r+ adds ready-to-merge, running adds bors-staging, merge leaves them",
        %{proj: proj} do
     labels_toml = ~s"""
     status = [ "ci" ]
@@ -2201,8 +2201,10 @@ defmodule BorsNG.Worker.BatcherTest do
 
     Batcher.handle_info({:poll, :once}, proj.id)
     assert Repo.get_by!(Batch, project_id: proj.id).state == :ok
-    refute "ready-to-merge" in labels_for(1)
-    refute "bors-staging" in labels_for(1)
+    # A successful merge deliberately leaves the labels in place: the PR is now
+    # closed and they stand as a historical record of how it merged.
+    assert "ready-to-merge" in labels_for(1)
+    assert "bors-staging" in labels_for(1)
   end
 
   test "queue labels: a terminal build failure flags awaiting-requeue", %{proj: proj} do

--- a/test/batcher/batcher_test.exs
+++ b/test/batcher/batcher_test.exs
@@ -2279,6 +2279,76 @@ defmodule BorsNG.Worker.BatcherTest do
     refute "bors-staging" in labels_for(1)
   end
 
+  test "queue labels: a batch timeout flags awaiting-requeue and clears queue labels",
+       %{proj: proj} do
+    labels_toml = ~s"""
+    status = [ "ci" ]
+    [labels]
+    on_queue = "ready-to-merge"
+    building = "bors-staging"
+    failed = "awaiting-requeue"
+    """
+
+    GitHub.ServerMock.put_state(%{
+      {{:installation, 91}, 14} => %{
+        branches: %{"master" => "ini", "staging" => "", "staging.tmp" => ""},
+        commits: %{},
+        comments: %{1 => []},
+        statuses: %{"iniN" => %{}},
+        files: %{
+          "staging.tmp" => %{"bors.toml" => labels_toml},
+          "master" => %{"bors.toml" => labels_toml}
+        },
+        pulls: %{
+          1 => %Pr{
+            number: 1,
+            title: "Test",
+            body: "Mess",
+            state: :open,
+            base_ref: "master",
+            head_sha: "N",
+            head_ref: "update",
+            base_repo_id: 14,
+            head_repo_id: 14,
+            merged: false
+          }
+        },
+        pr_commits: %{
+          1 => [%GitHub.Commit{sha: "1234", author_name: "a", author_email: "e"}]
+        }
+      }
+    })
+
+    patch =
+      %Patch{project_id: proj.id, pr_xref: 1, commit: "N", into_branch: "master"}
+      |> Repo.insert!()
+
+    Batcher.handle_cast({:reviewed, patch.id, "rvr"}, proj.id)
+
+    Repo.get_by!(Batch, project_id: proj.id)
+    |> Batch.changeset(%{last_polled: 0})
+    |> Repo.update!()
+
+    Batcher.handle_info({:poll, :once}, proj.id)
+    assert Repo.get_by!(Batch, project_id: proj.id).state == :running
+    assert "ready-to-merge" in labels_for(1)
+    assert "bors-staging" in labels_for(1)
+
+    # The running batch's deadline passes before CI reports: poll_batches sees
+    # timeout_is_past and routes to timeout_batch, the path that previously
+    # reconciled no labels at all.
+    Repo.get_by!(Batch, project_id: proj.id)
+    |> Batch.changeset(%{timeout_at: 0})
+    |> Repo.update!()
+
+    Batcher.handle_info({:poll, :once}, proj.id)
+    assert Repo.get_by!(Batch, project_id: proj.id).state == :error
+
+    assert "awaiting-requeue" in labels_for(1)
+    refute "ready-to-merge" in labels_for(1)
+    refute "bors-staging" in labels_for(1)
+  end
+
   test "full runthrough (with zero patches)", %{proj: proj} do
     # Create a zero-patch batch in a "waiting" state
     # This isn't normally possible through the user interface,

--- a/test/batcher/bors_toml_test.exs
+++ b/test/batcher/bors_toml_test.exs
@@ -249,4 +249,52 @@ defmodule BatcherBorsTomlTest do
 
     assert toml.delegation_restrict_to_paths == ["src/**/*.rs", "a?b"]
   end
+
+  test "defaults all [labels] entries to nil" do
+    {:ok, toml} = BorsToml.new(~s/status = ["exl"]/)
+    assert is_nil(toml.label_on_queue)
+    assert is_nil(toml.label_building)
+    assert is_nil(toml.label_failed)
+    assert is_nil(toml.label_delegated)
+  end
+
+  test "parses the [labels] table" do
+    {:ok, toml} =
+      BorsToml.new(~S"""
+      status = ["exl"]
+      [labels]
+      on_queue = "ready-to-merge"
+      building = "bors-staging"
+      failed = "awaiting-requeue"
+      delegated = "delegated"
+      """)
+
+    assert toml.label_on_queue == "ready-to-merge"
+    assert toml.label_building == "bors-staging"
+    assert toml.label_failed == "awaiting-requeue"
+    assert toml.label_delegated == "delegated"
+  end
+
+  test "parses a partial [labels] table, leaving the rest nil" do
+    {:ok, toml} =
+      BorsToml.new(~s/status = ["exl"]\n[labels]\ndelegated = "delegated"/)
+
+    assert toml.label_delegated == "delegated"
+    assert is_nil(toml.label_on_queue)
+  end
+
+  test "rejects a non-table [labels] value" do
+    r = BorsToml.new(~s/status = ["exl"]\nlabels = "nope"/)
+    assert r == {:error, :labels}
+  end
+
+  test "rejects a non-string [labels] entry" do
+    r = BorsToml.new(~s/status = ["exl"]\n[labels]\non_queue = 42/)
+    assert r == {:error, :labels}
+  end
+
+  test "rejects an empty-string [labels] entry" do
+    r = BorsToml.new(~s/status = ["exl"]\n[labels]\ndelegated = ""/)
+    assert r == {:error, :labels}
+  end
 end

--- a/test/batcher/bors_toml_test.exs
+++ b/test/batcher/bors_toml_test.exs
@@ -302,4 +302,20 @@ defmodule BatcherBorsTomlTest do
     r = BorsToml.new(~s/[labels]\non_queue = 42/)
     assert r == {:error, :labels}
   end
+
+  test "rejects a [labels] table that reuses a name across two concerns" do
+    r = BorsToml.new(~s/status = ["exl"]\n[labels]\non_queue = "x"\nfailed = "x"/)
+    assert r == {:error, :label_names_not_distinct}
+  end
+
+  test "allows distinct [labels] names" do
+    {:ok, toml} =
+      BorsToml.new(
+        ~s/status = ["exl"]\n[labels]\non_queue = "a"\nbuilding = "b"\ndelegated = "c"/
+      )
+
+    assert toml.label_on_queue == "a"
+    assert toml.label_building == "b"
+    assert toml.label_delegated == "c"
+  end
 end

--- a/test/batcher/bors_toml_test.exs
+++ b/test/batcher/bors_toml_test.exs
@@ -297,4 +297,9 @@ defmodule BatcherBorsTomlTest do
     r = BorsToml.new(~s/status = ["exl"]\n[labels]\ndelegated = ""/)
     assert r == {:error, :labels}
   end
+
+  test "reports :labels (not :empty_config) for an invalid [labels] table with no other config" do
+    r = BorsToml.new(~s/[labels]\non_queue = 42/)
+    assert r == {:error, :labels}
+  end
 end

--- a/test/batcher/get_bors_toml_cache_test.exs
+++ b/test/batcher/get_bors_toml_cache_test.exs
@@ -1,0 +1,81 @@
+defmodule BorsNG.Worker.Batcher.GetBorsTomlCacheTest do
+  use ExUnit.Case
+
+  alias BorsNG.GitHub
+  alias BorsNG.Worker.Batcher.GetBorsToml
+  alias BorsNG.Worker.Batcher.GetBorsToml.Cache
+
+  @conn {{:installation, 93}, 31}
+
+  setup do
+    # The global test config disables the cache (ttl 0). Start each test from a
+    # clean table and restore the configured ttl afterwards; the get_cached/2
+    # tests opt back into a real ttl as needed.
+    :ets.delete_all_objects(Cache.table())
+    prev = Application.get_env(:bors, :bors_toml_cache_ttl_ms)
+    on_exit(fn -> Application.put_env(:bors, :bors_toml_cache_ttl_ms, prev) end)
+    :ok
+  end
+
+  defp put_toml(contents) do
+    GitHub.ServerMock.put_state(%{
+      @conn => %{files: %{"master" => %{"bors.toml" => contents}}}
+    })
+  end
+
+  describe "Cache (ETS)" do
+    test "put then fetch returns the value while fresh" do
+      key = {:fresh, make_ref()}
+      assert {:ok, :sentinel} = Cache.put(key, {:ok, :sentinel}, 60_000)
+      assert {:ok, {:ok, :sentinel}} = Cache.fetch(key)
+    end
+
+    test "fetch misses an expired entry" do
+      key = {:expired, make_ref()}
+      Cache.put(key, {:ok, :sentinel}, 0)
+      assert :miss = Cache.fetch(key)
+    end
+
+    test "fetch misses an absent key" do
+      assert :miss = Cache.fetch({:absent, make_ref()})
+    end
+  end
+
+  describe "get_cached/2" do
+    test "serves the cached toml even after the source changes (within ttl)" do
+      Application.put_env(:bors, :bors_toml_cache_ttl_ms, 60_000)
+      put_toml(~s/status = ["ci"]\n/)
+
+      assert {:ok, first} = GetBorsToml.get_cached(@conn, "master")
+      assert first.status == ["ci"]
+
+      # The source changes, but the cached value is still within its ttl.
+      put_toml(~s/status = ["changed"]\n/)
+      assert {:ok, cached} = GetBorsToml.get_cached(@conn, "master")
+      assert cached.status == ["ci"]
+    end
+
+    test "a non-positive ttl bypasses the cache and always reads fresh" do
+      Application.put_env(:bors, :bors_toml_cache_ttl_ms, 0)
+      put_toml(~s/status = ["ci"]\n/)
+      assert {:ok, first} = GetBorsToml.get_cached(@conn, "master")
+      assert first.status == ["ci"]
+
+      put_toml(~s/status = ["fresh"]\n/)
+      assert {:ok, second} = GetBorsToml.get_cached(@conn, "master")
+      assert second.status == ["fresh"]
+    end
+
+    test "caches errors too" do
+      Application.put_env(:bors, :bors_toml_cache_ttl_ms, 60_000)
+      # No bors.toml and no CI config files => fetch_failed.
+      GitHub.ServerMock.put_state(%{@conn => %{files: %{"master" => %{}}}})
+
+      assert {:error, _} = GetBorsToml.get_cached(@conn, "master")
+
+      # A valid toml now exists, but the cached error is still served.
+      put_toml(~s/status = ["ci"]\n/)
+      assert {:error, _} = GetBorsToml.get_cached(@conn, "master")
+    end
+  end
+end

--- a/test/controllers/webhook_controller_test.exs
+++ b/test/controllers/webhook_controller_test.exs
@@ -305,6 +305,125 @@ defmodule BorsNG.WebhookControllerTest do
     assert Repo.all(Attempt.all_for_patch(patch.id, :incomplete)) == []
   end
 
+  test "closing a PR without merging wipes its delegations and clears the delegated label", %{
+    conn: conn,
+    project: proj,
+    user: user
+  } do
+    GitHub.ServerMock.put_state(%{
+      {{:installation, 31}, 13} => %{
+        branches: %{},
+        commits: %{},
+        comments: %{1 => []},
+        statuses: %{},
+        files: %{
+          "master" => %{"bors.toml" => ~s/status = ["ci"]\n[labels]\ndelegated = "delegated"\n/}
+        },
+        labels: %{1 => ["delegated"]}
+      }
+    })
+
+    patch =
+      Repo.insert!(%Patch{
+        project_id: proj.id,
+        pr_xref: 1,
+        commit: "C",
+        into_branch: "master",
+        open: true
+      })
+
+    Repo.insert!(%UserPatchDelegation{user_id: user.id, patch_id: patch.id})
+
+    body_params = %{
+      "repository" => %{"id" => 13},
+      "action" => "closed",
+      "pull_request" => %{
+        "number" => 1,
+        "title" => "T",
+        "body" => "B",
+        "state" => "closed",
+        "base" => %{"ref" => "master", "repo" => %{"id" => 13}},
+        "head" => %{"sha" => "C", "ref" => "feature", "repo" => %{"id" => 13}},
+        "merged_at" => nil,
+        "mergeable" => true,
+        "user" => %{"id" => 23, "login" => "ghost", "avatar_url" => "U"}
+      }
+    }
+
+    conn
+    |> put_req_header("x-github-event", "pull_request")
+    |> post(webhook_path(conn, :webhook, "github"), body_params)
+
+    # undelegate + label reconcile run synchronously in the closed handler.
+    assert Repo.all(from(d in UserPatchDelegation, where: d.patch_id == ^patch.id)) == []
+
+    labels =
+      GitHub.ServerMock.get_state()
+      |> get_in([{{:installation, 31}, 13}, :labels, 1])
+
+    refute "delegated" in labels
+  end
+
+  test "closing a merged PR keeps its delegations and the delegated label", %{
+    conn: conn,
+    project: proj,
+    user: user
+  } do
+    GitHub.ServerMock.put_state(%{
+      {{:installation, 31}, 13} => %{
+        branches: %{},
+        commits: %{},
+        comments: %{1 => []},
+        statuses: %{},
+        files: %{
+          "master" => %{"bors.toml" => ~s/status = ["ci"]\n[labels]\ndelegated = "delegated"\n/}
+        },
+        labels: %{1 => ["delegated"]}
+      }
+    })
+
+    patch =
+      Repo.insert!(%Patch{
+        project_id: proj.id,
+        pr_xref: 1,
+        commit: "C",
+        into_branch: "master",
+        open: true
+      })
+
+    Repo.insert!(%UserPatchDelegation{user_id: user.id, patch_id: patch.id})
+
+    body_params = %{
+      "repository" => %{"id" => 13},
+      "action" => "closed",
+      "pull_request" => %{
+        "number" => 1,
+        "title" => "T",
+        "body" => "B",
+        "state" => "closed",
+        "base" => %{"ref" => "master", "repo" => %{"id" => 13}},
+        "head" => %{"sha" => "C", "ref" => "feature", "repo" => %{"id" => 13}},
+        "merged_at" => "2020-01-01T00:00:00Z",
+        "mergeable" => true,
+        "user" => %{"id" => 23, "login" => "ghost", "avatar_url" => "U"}
+      }
+    }
+
+    conn
+    |> put_req_header("x-github-event", "pull_request")
+    |> post(webhook_path(conn, :webhook, "github"), body_params)
+
+    # A merged PR keeps its delegation rows (they expire and get swept) and its
+    # `delegated` label stays as a historical marker.
+    assert [_] = Repo.all(from(d in UserPatchDelegation, where: d.patch_id == ^patch.id))
+
+    labels =
+      GitHub.ServerMock.get_state()
+      |> get_in([{{:installation, 31}, 13}, :labels, 1])
+
+    assert "delegated" in labels
+  end
+
   test "synchronize webhook cancels active try jobs", %{conn: conn, project: proj} do
     patch =
       Repo.insert!(%Patch{
@@ -356,18 +475,22 @@ defmodule BorsNG.WebhookControllerTest do
     assert Repo.get!(Patch, patch.id).commit == "B"
   end
 
-  test "converting a PR to draft cancels active work, removes delegations, and posts notice", %{
-    conn: conn,
-    project: proj,
-    user: user
-  } do
+  test "converting a PR to draft cancels active work, removes delegations and the delegated label, and posts notice",
+       %{
+         conn: conn,
+         project: proj,
+         user: user
+       } do
     GitHub.ServerMock.put_state(%{
       {{:installation, 31}, 13} => %{
         branches: %{},
         commits: %{},
         comments: %{1 => []},
         statuses: %{},
-        files: %{}
+        files: %{
+          "master" => %{"bors.toml" => ~s/status = ["ci"]\n[labels]\ndelegated = "delegated"\n/}
+        },
+        labels: %{1 => ["delegated"]}
       }
     })
 
@@ -445,6 +568,13 @@ defmodule BorsNG.WebhookControllerTest do
 
     assert Enum.any?(comments, &String.contains?(&1, "now in draft mode"))
     assert Enum.any?(comments, &String.contains?(&1, "will ignore commands"))
+
+    # The delegations are gone, so the `delegated` label is reconciled off too.
+    labels =
+      GitHub.ServerMock.get_state()
+      |> get_in([{{:installation, 31}, 13}, :labels, 1])
+
+    refute "delegated" in labels
   end
 
   test "ignore pull_request_review_comment commands on draft PR", %{conn: conn} do

--- a/test/delegation_test.exs
+++ b/test/delegation_test.exs
@@ -138,9 +138,10 @@ defmodule BorsNG.Database.Context.DelegationTest do
       user: user,
       patch: patch
     } do
-      put_state_with_bors_toml(~s/status = ["ci"]\n[labels]\ndelegated = "delegated"\n/, [
-        "delegated"
-      ])
+      # Seed the label *absent* so the assertion proves the keep-path actually
+      # reconciles it to present (adds it), rather than passing on a pre-seeded
+      # label that a no-op keep would also leave in place.
+      put_state_with_bors_toml(~s/status = ["ci"]\n[labels]\ndelegated = "delegated"\n/, [])
 
       bob = Repo.insert!(%User{user_xref: 42, login: "bob"})
 

--- a/test/delegation_test.exs
+++ b/test/delegation_test.exs
@@ -69,6 +69,24 @@ defmodule BorsNG.Database.Context.DelegationTest do
     })
   end
 
+  # Like put_state_with_bors_toml/1, but also seeds the PR's existing labels so
+  # the sweep's label reconcile has something to remove.
+  defp put_state_with_bors_toml(contents, labels) do
+    GitHub.ServerMock.put_state(%{
+      {{:installation, 92}, 21} => %{
+        branches: %{},
+        comments: %{7 => []},
+        statuses: %{},
+        files: %{"master" => %{"bors.toml" => contents}},
+        labels: %{7 => labels}
+      }
+    })
+  end
+
+  defp labels do
+    GitHub.ServerMock.get_state() |> get_in([{{:installation, 92}, 21}, :labels, 7])
+  end
+
   describe "sweep/0" do
     test "deletes expired delegations and posts a notification", %{user: user, patch: patch} do
       past =
@@ -88,6 +106,73 @@ defmodule BorsNG.Database.Context.DelegationTest do
       assert [] == Repo.all(UserPatchDelegation)
       assert Enum.any?(comments(), &String.contains?(&1, "Delegation for @alice"))
       assert Enum.any?(comments(), &String.contains?(&1, "expired"))
+    end
+
+    test "removes the delegated label when the last delegation expires", %{
+      user: user,
+      patch: patch
+    } do
+      put_state_with_bors_toml(~s/status = ["ci"]\n[labels]\ndelegated = "delegated"\n/, [
+        "delegated"
+      ])
+
+      past =
+        NaiveDateTime.utc_now()
+        |> NaiveDateTime.add(-3600, :second)
+        |> NaiveDateTime.truncate(:second)
+
+      Repo.insert!(%UserPatchDelegation{
+        user_id: user.id,
+        patch_id: patch.id,
+        expires_at: past,
+        delegated_at_commit: "abc"
+      })
+
+      Delegation.sweep()
+
+      assert [] == Repo.all(UserPatchDelegation)
+      refute "delegated" in labels()
+    end
+
+    test "keeps the delegated label while another delegation is still active", %{
+      user: user,
+      patch: patch
+    } do
+      put_state_with_bors_toml(~s/status = ["ci"]\n[labels]\ndelegated = "delegated"\n/, [
+        "delegated"
+      ])
+
+      bob = Repo.insert!(%User{user_xref: 42, login: "bob"})
+
+      past =
+        NaiveDateTime.utc_now()
+        |> NaiveDateTime.add(-3600, :second)
+        |> NaiveDateTime.truncate(:second)
+
+      future =
+        NaiveDateTime.utc_now()
+        |> NaiveDateTime.add(30 * 24 * 3600, :second)
+        |> NaiveDateTime.truncate(:second)
+
+      Repo.insert!(%UserPatchDelegation{
+        user_id: user.id,
+        patch_id: patch.id,
+        expires_at: past,
+        delegated_at_commit: "abc"
+      })
+
+      Repo.insert!(%UserPatchDelegation{
+        user_id: bob.id,
+        patch_id: patch.id,
+        expires_at: future,
+        delegated_at_commit: "abc"
+      })
+
+      Delegation.sweep()
+
+      assert [remaining] = Repo.all(UserPatchDelegation)
+      assert remaining.user_id == bob.id
+      assert "delegated" in labels()
     end
 
     test "does not post expired comment when patch is closed", %{user: user, patch: patch} do

--- a/test/github_server_mock_test.exs
+++ b/test/github_server_mock_test.exs
@@ -1,5 +1,52 @@
 defmodule BorsNG.GitHub.ServerMockTest do
   use ExUnit.Case
 
+  alias BorsNG.GitHub
+  alias BorsNG.GitHub.ServerMock
+
   doctest BorsNG.GitHub.ServerMock
+
+  describe "labels" do
+    @conn {{:installation, 91}, 14}
+
+    setup do
+      ServerMock.put_state(%{
+        @conn => %{
+          labels: %{1 => ["existing"]}
+        }
+      })
+
+      :ok
+    end
+
+    test "add_labels adds a label without duplicating" do
+      assert :ok = GitHub.add_labels(@conn, 1, ["ready-to-merge"])
+      # Adding a label that's already present is idempotent.
+      assert :ok = GitHub.add_labels(@conn, 1, ["existing"])
+
+      labels = GitHub.get_labels!(@conn, 1)
+      assert "ready-to-merge" in labels
+      assert Enum.count(labels, &(&1 == "existing")) == 1
+    end
+
+    test "add_labels works when the issue has no labels yet" do
+      assert :ok = GitHub.add_labels(@conn, 2, ["delegated"])
+      assert GitHub.get_labels!(@conn, 2) == ["delegated"]
+    end
+
+    test "add_labels with an empty list is a no-op" do
+      assert :ok = GitHub.add_labels(@conn, 1, [])
+      assert GitHub.get_labels!(@conn, 1) == ["existing"]
+    end
+
+    test "remove_label removes a present label" do
+      assert :ok = GitHub.remove_label(@conn, 1, "existing")
+      assert GitHub.get_labels!(@conn, 1) == []
+    end
+
+    test "remove_label is a no-op for an absent label" do
+      assert :ok = GitHub.remove_label(@conn, 1, "not-there")
+      assert GitHub.get_labels!(@conn, 1) == ["existing"]
+    end
+  end
 end

--- a/test/github_server_mock_test.exs
+++ b/test/github_server_mock_test.exs
@@ -49,4 +49,35 @@ defmodule BorsNG.GitHub.ServerMockTest do
       assert GitHub.get_labels!(@conn, 1) == ["existing"]
     end
   end
+
+  describe "list_issues_by_label" do
+    @conn {{:installation, 91}, 14}
+
+    setup do
+      ServerMock.put_state(%{
+        @conn => %{
+          labels: %{
+            1 => ["ready-to-merge", "delegated"],
+            2 => ["ready-to-merge"],
+            3 => ["other"]
+          }
+        }
+      })
+
+      :ok
+    end
+
+    test "returns each matching issue with its full label set" do
+      assert {:ok, issues} = GitHub.list_issues_by_label(@conn, "ready-to-merge")
+
+      assert Enum.sort(issues) == [
+               {1, ["ready-to-merge", "delegated"]},
+               {2, ["ready-to-merge"]}
+             ]
+    end
+
+    test "returns an empty list when no issue carries the label" do
+      assert {:ok, []} = GitHub.list_issues_by_label(@conn, "nonexistent")
+    end
+  end
 end

--- a/test/worker/labeler_backstop_test.exs
+++ b/test/worker/labeler_backstop_test.exs
@@ -1,0 +1,185 @@
+defmodule BorsNG.Worker.LabelerBackstopTest do
+  use ExUnit.Case
+
+  alias BorsNG.Database.Batch
+  alias BorsNG.Database.Installation
+  alias BorsNG.Database.LinkPatchBatch
+  alias BorsNG.Database.Patch
+  alias BorsNG.Database.Project
+  alias BorsNG.Database.Repo
+  alias BorsNG.Database.User
+  alias BorsNG.Database.UserPatchDelegation
+  alias BorsNG.GitHub
+  alias BorsNG.Worker.Labeler
+
+  @conn {{:installation, 92}, 21}
+
+  @all_labels ~s"""
+  status = ["ci"]
+  [labels]
+  on_queue = "ready-to-merge"
+  building = "bors-staging"
+  delegated = "delegated"
+  failed = "awaiting-requeue"
+  """
+
+  setup do
+    :ok = Ecto.Adapters.SQL.Sandbox.checkout(Repo)
+    Ecto.Adapters.SQL.Sandbox.mode(Repo, {:shared, self()})
+
+    inst = Repo.insert!(%Installation{installation_xref: 92})
+
+    proj =
+      Repo.insert!(%Project{
+        installation_id: inst.id,
+        repo_xref: 21,
+        staging_branch: "staging",
+        name: "example/labels"
+      })
+
+    user = Repo.insert!(%User{user_xref: 41, login: "alice"})
+
+    patch =
+      Repo.insert!(%Patch{
+        project_id: proj.id,
+        pr_xref: 7,
+        commit: "abc",
+        into_branch: "master",
+        open: true
+      })
+
+    {:ok, proj: proj, user: user, patch: patch}
+  end
+
+  # Seed the repo's bors.toml (on master) and per-PR labels.
+  defp seed(bors_toml, labels) do
+    GitHub.ServerMock.put_state(%{
+      @conn => %{
+        branches: %{},
+        comments: %{},
+        statuses: %{},
+        files: %{"master" => %{"bors.toml" => bors_toml}},
+        labels: labels
+      }
+    })
+  end
+
+  defp labels_for(pr) do
+    GitHub.ServerMock.get_state() |> get_in([@conn, :labels, pr]) || []
+  end
+
+  defp delegate(user, patch) do
+    future =
+      NaiveDateTime.utc_now()
+      |> NaiveDateTime.add(3600, :second)
+      |> NaiveDateTime.truncate(:second)
+
+    Repo.insert!(%UserPatchDelegation{
+      user_id: user.id,
+      patch_id: patch.id,
+      expires_at: future,
+      delegated_at_commit: "abc"
+    })
+  end
+
+  defp link_to_batch(patch, state) do
+    batch = Repo.insert!(%{Batch.new(patch.project_id, "master") | state: state})
+    Repo.insert!(%LinkPatchBatch{patch_id: patch.id, batch_id: batch.id, reviewer: "alice"})
+    batch
+  end
+
+  test "removes a stranded delegated label when no delegation is active", %{patch: _patch} do
+    seed(@all_labels, %{7 => ["delegated"]})
+
+    Labeler.backstop_sweep()
+
+    refute "delegated" in labels_for(7)
+  end
+
+  test "removes a stranded on_queue label when the PR is not queued" do
+    seed(@all_labels, %{7 => ["ready-to-merge"]})
+
+    Labeler.backstop_sweep()
+
+    refute "ready-to-merge" in labels_for(7)
+  end
+
+  test "adds a missing delegated label (add-gap) when a delegation is active", %{
+    user: user,
+    patch: patch
+  } do
+    delegate(user, patch)
+    seed(@all_labels, %{7 => []})
+
+    Labeler.backstop_sweep()
+
+    assert "delegated" in labels_for(7)
+  end
+
+  test "adds missing queue labels (add-gap) for a running batch", %{patch: patch} do
+    link_to_batch(patch, :running)
+    seed(@all_labels, %{7 => []})
+
+    Labeler.backstop_sweep()
+
+    labels = labels_for(7)
+    assert "ready-to-merge" in labels
+    assert "bors-staging" in labels
+  end
+
+  test "leaves a stale failed label alone when the PR is not on the queue", %{patch: _patch} do
+    # PR carries only awaiting-requeue and is neither queued nor delegated: the
+    # undecidable case (genuine limbo vs a missed r-/close clear), left alone.
+    seed(@all_labels, %{7 => ["awaiting-requeue"]})
+
+    Labeler.backstop_sweep()
+
+    assert "awaiting-requeue" in labels_for(7)
+  end
+
+  test "clears a stale failed label once the PR is back on the queue", %{patch: patch} do
+    # A dropped requeue-clear: the PR was re-queued (now on a live batch) but
+    # still carries awaiting-requeue. This is the one decidable direction.
+    link_to_batch(patch, :waiting)
+    seed(@all_labels, %{7 => ["ready-to-merge", "awaiting-requeue"]})
+
+    Labeler.backstop_sweep()
+
+    labels = labels_for(7)
+    refute "awaiting-requeue" in labels
+    assert "ready-to-merge" in labels
+  end
+
+  test "is a no-op when [labels] is unset" do
+    seed(~s/status = ["ci"]\n/, %{7 => ["delegated"]})
+
+    Labeler.backstop_sweep()
+
+    # No managed names, so the project is skipped and the label is left alone.
+    assert "delegated" in labels_for(7)
+  end
+
+  test "never touches a closed/merged PR", %{patch: patch} do
+    Repo.update!(Ecto.Changeset.change(patch, open: false))
+    seed(@all_labels, %{7 => ["delegated"]})
+
+    Labeler.backstop_sweep()
+
+    # The discovery listing surfaces it (the mock doesn't filter by state), but
+    # the open-patch gate means a merged PR's labels stay frozen.
+    assert "delegated" in labels_for(7)
+  end
+
+  test "writes nothing when labels already match state (diff-based)", %{
+    user: user,
+    patch: patch
+  } do
+    delegate(user, patch)
+    seed(@all_labels, %{7 => ["delegated"]})
+
+    Labeler.backstop_sweep()
+
+    # Still present exactly once: no spurious add or remove.
+    assert labels_for(7) == ["delegated"]
+  end
+end

--- a/test/worker/labeler_backstop_test.exs
+++ b/test/worker/labeler_backstop_test.exs
@@ -182,4 +182,113 @@ defmodule BorsNG.Worker.LabelerBackstopTest do
     # Still present exactly once: no spurious add or remove.
     assert labels_for(7) == ["delegated"]
   end
+
+  test "removes a stranded building label while keeping on_queue (waiting batch)", %{patch: patch} do
+    link_to_batch(patch, :waiting)
+    seed(@all_labels, %{7 => ["ready-to-merge", "bors-staging"]})
+
+    Labeler.backstop_sweep()
+
+    labels = labels_for(7)
+    # Waiting (not running): on the queue but not building.
+    assert "ready-to-merge" in labels
+    refute "bors-staging" in labels
+  end
+
+  test "leaves a label the PR's current base config does not manage", %{proj: proj, patch: patch} do
+    # PR #7 targets "dev", whose config has no [labels]; only "master" defines
+    # on_queue. A second open patch on master puts that config in play.
+    Repo.update!(Ecto.Changeset.change(patch, into_branch: "dev"))
+
+    Repo.insert!(%Patch{
+      project_id: proj.id,
+      pr_xref: 8,
+      commit: "def",
+      into_branch: "master",
+      open: true
+    })
+
+    GitHub.ServerMock.put_state(%{
+      @conn => %{
+        files: %{
+          "master" => %{"bors.toml" => @all_labels},
+          "dev" => %{"bors.toml" => ~s/status = ["ci"]\n/}
+        },
+        labels: %{7 => ["ready-to-merge"]}
+      }
+    })
+
+    Labeler.backstop_sweep()
+
+    # "ready-to-merge" is managed on master but not on dev (PR #7's base), so the
+    # sweep must not strip it — the documented divergent-name retarget case.
+    assert "ready-to-merge" in labels_for(7)
+  end
+
+  test "leaves a label on a PR bors does not track" do
+    seed(@all_labels, %{999 => ["delegated"]})
+
+    Labeler.backstop_sweep()
+
+    # No patch row for #999, so the sweep can't compute desired state for it and
+    # leaves the label alone.
+    assert "delegated" in labels_for(999)
+  end
+
+  test "reconciles a configured project and skips an unconfigured one in one sweep", %{proj: proj} do
+    inst = Repo.get!(Installation, proj.installation_id)
+
+    proj2 =
+      Repo.insert!(%Project{
+        installation_id: inst.id,
+        repo_xref: 22,
+        staging_branch: "staging",
+        name: "example/other"
+      })
+
+    Repo.insert!(%Patch{
+      project_id: proj2.id,
+      pr_xref: 70,
+      commit: "ghi",
+      into_branch: "master",
+      open: true
+    })
+
+    conn2 = {{:installation, 92}, 22}
+
+    GitHub.ServerMock.put_state(%{
+      @conn => %{
+        files: %{"master" => %{"bors.toml" => @all_labels}},
+        labels: %{7 => ["delegated"]}
+      },
+      conn2 => %{
+        files: %{"master" => %{"bors.toml" => ~s/status = ["ci"]\n/}},
+        labels: %{70 => ["delegated"]}
+      }
+    })
+
+    Labeler.backstop_sweep()
+
+    # proj manages `delegated` and #7 has no active delegation -> removed.
+    refute "delegated" in labels_for(7)
+    # proj2 has no [labels] -> its stranded label is untouched.
+    proj2_labels = GitHub.ServerMock.get_state() |> get_in([conn2, :labels, 70]) || []
+    assert "delegated" in proj2_labels
+  end
+
+  test "tolerates a label-discovery failure without crashing or touching labels" do
+    GitHub.ServerMock.put_state(%{
+      @conn => %{
+        files: %{"master" => %{"bors.toml" => @all_labels}},
+        labels: %{7 => ["delegated"]}
+      },
+      list_issues_by_label_error: true
+    })
+
+    assert :ok = Labeler.backstop_sweep()
+
+    # Discovery errored, so the stranded label isn't reconciled away this tick
+    # (it retries next sweep); the run completed without raising.
+    assert "delegated" in labels_for(7)
+  end
 end


### PR DESCRIPTION
Moves the `ready-to-merge` and `delegated` labels off mathlib4's comment-parsing GitHub Actions and into bors, where the state actually lives. The Actions can only react to comments, so they never removed the `delegated` label when a delegation expired, was revoked by a sensitive-path push, or was the last of several to go — the bug users have been hitting since delegation expiry landed.

Adds a label read/write API to the GitHub client (`add_labels` / `remove_label` / `list_issues_by_label`) and a `BorsNG.Worker.Labeler` that reconciles managed labels toward the database, best-effort (a failed call is logged, never raised). Label management is opt-in per project via a `[labels]` table in `bors.toml` (`on_queue`, `building`, `failed`, `delegated`); absent keys are unmanaged, so other repos see no change.

`delegated` is reconciled at create / `d-` / timed expiry / path invalidation, staying on until the last active delegatee is gone. The queue labels are state-derived from the batch lifecycle: `ready-to-merge` while a patch is queued (waiting or running), `bors-staging` while it's building, and the event-driven `awaiting-requeue` when an approved PR's build fails terminally and it's dropped — cleared automatically when it's put back on the queue.

On top of those per-event reconciles, a periodic **backstop sweep** (`Labeler.backstop_sweep/0`, on its own `LabelBackstopTimer`) self-heals any drift the events can't catch — a best-effort write dropped at the time, a restart mid-transition, or a manual label edit. It is discovery-driven and diff-based: per project it lists the PRs carrying each managed label (`list_issues_by_label`, whose response already includes every PR's full label set), recomputes the desired state, and writes only the difference, so a sweep that finds no drift performs no writes. It touches only open PRs (a merged PR's labels stay frozen as history) and only the label names the PR's current base-branch config manages. `awaiting-requeue` is reconciled asymmetrically: never added (its state isn't derivable from the DB) and cleared only once the PR is back on the queue.

The reconcile paths re-read each base branch's `bors.toml`, so they go through a short-TTL `(repo, branch)` config cache (`GetBorsToml.get_cached/2`, backed by an ETS-owning `GetBorsToml.Cache`) that keeps the sweep's and the delegation pass's config reads cheap. The batcher's merge-decision reads stay uncached, so a stale config can never drive a merge.

Closing a PR without merging (and converting one to draft) now also wipes its delegations, so the `delegated` label comes off an abandoned PR rather than lingering.

See `LIFECYCLE_LABELS.md` for the full design. The mathlib4 workflow cleanup (adding the `[labels]` table and removing the label logic from `maintainer_bors*.yml`) lands separately, after this deploys; the operations are idempotent so the overlap is safe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
