### PR TITLE
feat(dashboard): list all projects for admins

### DIFF
--- a/lib/database/context/dashboard.ex
+++ b/lib/database/context/dashboard.ex
@@ -40,6 +40,17 @@ defmodule BorsNG.Database.Context.Dashboard do
     |> Repo.all()
   end
 
+  @doc """
+  List every project, ignoring membership. Used for admins, who can access
+  any repo regardless of the reviewer/member links.
+  """
+  def all_projects do
+    from(p in Project,
+      order_by: [asc: p.name, asc: p.repo_xref]
+    )
+    |> Repo.all()
+  end
+
   def my_patches(user_id, type \\ :all)
 
   def my_patches(user_id, :reviewer) do

--- a/lib/web/controllers/project_controller.ex
+++ b/lib/web/controllers/project_controller.ex
@@ -82,7 +82,17 @@ defmodule BorsNG.ProjectController do
   end
 
   defp index_(conn, filter) do
-    projects = Dashboard.my_projects(conn.assigns.user.id, filter)
+    user = conn.assigns.user
+
+    projects =
+      if user.is_admin do
+        # Admins can access any repo, so surface all of them in the listing
+        # too, not just the ones they're a member/reviewer of.
+        Dashboard.all_projects()
+      else
+        Dashboard.my_projects(user.id, filter)
+      end
+
     render(conn, "index.html", projects: projects, filter: filter)
   end
 

--- a/test/context/dashboard_test.exs
+++ b/test/context/dashboard_test.exs
@@ -114,6 +114,19 @@ defmodule BorsNG.Database.DashboardContextTest do
     assert [context.project.id, project2.id] == Enum.sort(ids)
   end
 
+  test "all_projects lists every project regardless of membership", context do
+    project2 =
+      Repo.insert!(%Project{
+        installation_id: context.installation.id,
+        repo_xref: 14,
+        name: "example/project2"
+      })
+
+    projects = Dashboard.all_projects()
+    ids = projects |> Enum.map(& &1.id) |> Enum.sort()
+    assert ids == Enum.sort([context.project.id, project2.id])
+  end
+
   test "grab patches that a particular user has", %{project: project} do
     batch = Repo.insert!(%Batch{project: project, state: 0})
 

--- a/test/controllers/project_controller_test.exs
+++ b/test/controllers/project_controller_test.exs
@@ -72,6 +72,13 @@ defmodule BorsNG.ProjectControllerTest do
     assert html_response(conn, 200) =~ "example/project"
   end
 
+  test "admin lists all projects, even unlinked ones", %{conn: conn, user: user} do
+    conn = login(conn)
+    Repo.update!(Ecto.Changeset.change(user, is_admin: true))
+    conn = get(conn, project_path(conn, :index))
+    assert html_response(conn, 200) =~ "example/project"
+  end
+
   test "show an unbatched patch", %{conn: conn, project: project, user: user} do
     conn = login(conn)
     Repo.insert!(%Batch{project_id: project.id})


### PR DESCRIPTION
Admins can already open and edit any repo directly (ProjectController elevates them to :rw regardless of membership), but the dashboard listing was not admin-aware: it only showed repos where the user was a member or reviewer. Add Dashboard.all_projects/0 and use it in the listing when the current user is an admin, so admins can discover every repo from the dashboard, matching the access they already have.