### PR TITLE
fix(delegation): acknowledge standing approvals when a delegation ends

### DIFF
--- a/DELEGATION_INVALIDATION.md
+++ b/DELEGATION_INVALIDATION.md
@@ -173,6 +173,41 @@ rationale. The advisory `invalidate_on_paths` lint deliberately stays on the
 short budget: its reads (`get_repo_tree`, `get_pr_comments`) only gate a
 cosmetic warning, so a failure just skips it.
 
+### After approval — standing approvals are not re-checked
+
+The merge-time gate runs when the `r+` is issued. What that `r+` produces is a
+**standing approval**: for an unbundled patch, membership in a waiting or
+running batch; for a bundled patch, an approval held on the patch row
+(`Bundles.hold_approval/2`) until the rest of the bundle is approved. If the
+delegation that authorized it later expires or is removed with
+`bors delegate-`, the standing approval still counts — the batch stays queued,
+the held approval still lets the bundle queue once its last member is
+approved, and nothing re-validates delegation state at that point.
+
+This is deliberate:
+
+- The approval was verified fail-closed at the moment it was given. Queueing
+  or holding it is bookkeeping, not a new grant of trust.
+- The *security-motivated* invalidation path cannot race a standing approval:
+  path-based revocation only triggers on a push, and a push already cancels
+  the in-flight batch (the `synchronize` handler) or drops the held bundle
+  approval (the batcher's cancel path), so re-approval after the push goes
+  back through the fail-closed gate.
+- Any reviewer can retract a standing approval at any time with `bors r-`.
+- The residual cases — manual `delegate-`, timed expiry — are administrative:
+  the delegate was entitled when they approved.
+
+The user-facing messages acknowledge this rather than contradict it. When a
+delegation expires or is removed while its holder's approval stands, the
+expiry notice and the `delegate-` acknowledgment add that the approval still
+counts and how to retract it; the pre-expiry warnings tell an
+already-approved delegate that only *future* approvals need the delegation
+(their approval can still be dropped by a push, `bors r-`, or a failed build,
+after which re-approving requires a fresh delegation). The rule, in one line:
+**expiry or revocation never voids a standing approval; it only blocks future
+approvals.** The standing-approval check backing these messages is
+`BorsNG.Database.Context.Delegation.standing_approval?/2`.
+
 ### On close or convert-to-draft (full wipe)
 
 Two lifecycle events drop a PR's delegations outright, independent of the

--- a/lib/database/context/delegation.ex
+++ b/lib/database/context/delegation.ex
@@ -24,6 +24,12 @@ defmodule BorsNG.Database.Context.Delegation do
   `BorsNG.Database.Context.Permission.patch_delegated_reviewer?/2`, which
   ignores delegations whose `expires_at` has passed. The deletes here are
   therefore housekeeping plus notification, not access control.
+
+  Expiry also never withdraws a *standing approval* — an `r+` already queued in
+  a batch or held for a bundle (see `standing_approval?/2` and
+  DELEGATION_INVALIDATION.md, "standing approvals"). When the expiring
+  delegate holds one, the warning and expired notices say so rather than
+  implying the approval is void.
   """
 
   use BorsNG.Database.Context
@@ -119,6 +125,40 @@ defmodule BorsNG.Database.Context.Delegation do
         "following a `default_expiry_sec` setting in `bors.toml`."
 
     safe_post_comment(project, patch.pr_xref, msg)
+  end
+
+  @doc """
+  Whether `login`'s approval on this patch currently stands: queued in an
+  incomplete batch (unbundled), or held on the patch for its bundle. Neither
+  delegation expiry nor `bors delegate-` withdraws such an approval — the
+  merge-time delegation gate already ran, fail-closed, when the `r+` was
+  issued (see DELEGATION_INVALIDATION.md, "standing approvals"). Callers use
+  this to acknowledge the standing approval in comments, not to alter it.
+  """
+  def standing_approval?(patch_id, login) do
+    Repo.exists?(from(p in Patch, where: p.id == ^patch_id and p.bundle_reviewer == ^login)) or
+      Repo.exists?(
+        from(l in LinkPatchBatch,
+          join: b in Batch,
+          on: l.batch_id == b.id,
+          where: l.patch_id == ^patch_id and l.reviewer == ^login,
+          where: b.state == ^:waiting or b.state == ^:running
+        )
+      )
+  end
+
+  @doc """
+  Whether any of the patch's current delegates holds the standing approval.
+  Call *before* deleting the delegations — it enumerates them.
+  """
+  def standing_approval_by_delegate?(patch_id) do
+    from(d in UserPatchDelegation,
+      join: u in assoc(d, :user),
+      where: d.patch_id == ^patch_id,
+      select: u.login
+    )
+    |> Repo.all()
+    |> Enum.any?(&standing_approval?(patch_id, &1))
   end
 
   defp expire_delegations do
@@ -255,10 +295,19 @@ defmodule BorsNG.Database.Context.Delegation do
   end
 
   defp post_expired_comment(d) do
+    note =
+      if standing_approval?(d.patch_id, d.user.login) do
+        " Note: the approval @#{d.user.login} already gave still counts — expiry does not " <>
+          "withdraw a standing approval. A reviewer can retract it with `bors r-`."
+      else
+        ""
+      end
+
     msg =
       ":hourglass: Delegation for @#{d.user.login} on this PR has expired " <>
         "(at #{Command.format_expires_at(d.expires_at)}). " <>
-        "Reply with `bors d+` or `bors d=#{d.user.login}` with a `for=` argument to re-delegate."
+        "Reply with `bors d+` or `bors d=#{d.user.login}` with a `for=` argument to re-delegate." <>
+        note
 
     safe_post_comment(d.patch.project, d.patch.pr_xref, msg)
   end
@@ -268,10 +317,23 @@ defmodule BorsNG.Database.Context.Delegation do
     secs_remaining = NaiveDateTime.diff(d.expires_at, now)
     duration_str = Command.format_duration(secs_remaining)
 
+    # The delegate may have approved already; expiry only threatens *future*
+    # approvals, so say which situation they are in rather than implying the
+    # standing approval is at risk.
+    note =
+      if standing_approval?(d.patch_id, d.user.login) do
+        " Your existing approval is not affected — but if it is dropped (a new push, " <>
+          "`bors r-`, or a failed build), approving again after the delegation expires " <>
+          "will need a fresh delegation."
+      else
+        ""
+      end
+
     msg =
       ":hourglass_flowing_sand: @#{d.user.login}, your delegation on this PR expires " <>
         "in less than #{label} " <>
-        "(approximately #{duration_str}, at #{Command.format_expires_at(d.expires_at)})."
+        "(approximately #{duration_str}, at #{Command.format_expires_at(d.expires_at)})." <>
+        note
 
     safe_post_comment(d.patch.project, d.patch.pr_xref, msg)
   end

--- a/lib/web/command.ex
+++ b/lib/web/command.ex
@@ -627,6 +627,13 @@ defmodule BorsNG.Command do
             # is re-checked against the current head and fails closed. If the
             # gate denies, it has already revoked + commented (or explained an
             # unverifiable check), so don't also post the generic denial.
+            #
+            # For a bundled patch this is the only delegation check the
+            # approval ever gets: "merge time" is hold time. The r+ this gate
+            # blesses may be held on the patch (`Bundles.hold_approval/2`)
+            # until the rest of the bundle is approved, and is not re-checked
+            # when the bundle later queues. See DELEGATION_INVALIDATION.md,
+            # "standing approvals".
             required_permission == :reviewer and
                 DelegationInvalidator.verify_for_merge(c.patch, c.commenter) == :deny ->
               :ok
@@ -907,6 +914,14 @@ defmodule BorsNG.Command do
   end
 
   def run(c, :undelegate) do
+    # Checked before the delete: it enumerates the delegations being removed.
+    held_note =
+      if Delegation.standing_approval_by_delegate?(c.patch.id) do
+        ~s{ Note: an approval already given under a removed delegation still counts. A reviewer can retract it with `bors r-`.}
+      else
+        ""
+      end
+
     Permission.undelegate_patch(c.patch.id)
 
     Labeler.reconcile_delegated(c.patch)
@@ -917,12 +932,20 @@ defmodule BorsNG.Command do
     |> Project.installation_connection(Repo)
     |> GitHub.post_comment!(
       c.pr_xref,
-      ~s{:no_entry_sign: All delegations have been removed from this PR. To re-add a delegation, reply with `bors d+` (to delegate the PR author) or `bors d=list,of,github,usernames` to delegate multiple users.}
+      ~s{:no_entry_sign: All delegations have been removed from this PR. To re-add a delegation, reply with `bors d+` (to delegate the PR author) or `bors d=list,of,github,usernames` to delegate multiple users.} <>
+        held_note
     )
   end
 
   def run(c, {:undelegate_to, login}) do
     undelegatee = get_or_insert_user_by_login(c, login)
+
+    held_note =
+      if Delegation.standing_approval?(c.patch.id, undelegatee.login) do
+        ~s{ Note: the approval #{undelegatee.login} already gave still counts. A reviewer can retract it with `bors r-`.}
+      else
+        ""
+      end
 
     Permission.undelegate(undelegatee.id, c.patch.id)
 
@@ -940,7 +963,8 @@ defmodule BorsNG.Command do
     |> Project.installation_connection(Repo)
     |> GitHub.post_comment!(
       c.pr_xref,
-      ~s{:no_entry_sign: This PR is no longer delegated to #{undelegatee.login}. To re-add their delegation, reply with `#{readd_command}`.}
+      ~s{:no_entry_sign: This PR is no longer delegated to #{undelegatee.login}. To re-add their delegation, reply with `#{readd_command}`.} <>
+        held_note
     )
   end
 

--- a/lib/worker/batcher/bundles.ex
+++ b/lib/worker/batcher/bundles.ex
@@ -54,6 +54,14 @@ defmodule BorsNG.Worker.Batcher.Bundles do
   Record a reviewer's approval on a bundled patch. The approval is held until
   the rest of the bundle is approved. Returns the updated patch.
 
+  The held approval is not re-validated against delegation state when the
+  bundle later queues: if the reviewer approved under a delegation that has
+  since expired or been revoked, the approval still counts. That is deliberate
+  — the fail-closed delegation gate already ran when the `r+` was issued, and
+  a push to this patch drops the hold via the batcher's cancel path, so
+  re-approval goes back through the gate. See DELEGATION_INVALIDATION.md,
+  "standing approvals".
+
   Invariant: a draft cannot hold an approval. It is enforced only at the
   webhook boundary — every command entry point in `BorsNG.WebhookController`
   (issue_comment, review_comment, review, and the PR-opened body handler)

--- a/lib/worker/delegation_invalidator.ex
+++ b/lib/worker/delegation_invalidator.ex
@@ -21,6 +21,12 @@ defmodule BorsNG.Worker.DelegationInvalidator do
   ceilings and the resulting truncation policy, the synchronize-time
   (fail-open) versus merge-time (fail-closed) checks, and the user-facing
   messages — lives in `DELEGATION_INVALIDATION.md` at the repo root.
+
+  This module has no bundle awareness, deliberately: the merge-time gate runs
+  when the `r+` is issued, and a *standing approval* that results — a queued
+  batch, or an approval held for a bundle — is not re-checked if the
+  delegation later expires or is revoked. See DELEGATION_INVALIDATION.md,
+  "standing approvals", for why that is safe.
   """
 
   import Ecto.Query

--- a/test/command_test.exs
+++ b/test/command_test.exs
@@ -792,6 +792,109 @@ defmodule BorsNG.CommandTest do
     ]
   end
 
+  # Removing a delegation never withdraws a standing approval (here: one held
+  # for a bundle); the acknowledgment has to say so instead of implying the
+  # approval is gone.
+  defp undelegate_note_setup(proj) do
+    GitHub.ServerMock.put_state(%{
+      {{:installation, 91}, 14} => %{
+        branches: %{},
+        comments: %{1 => []},
+        statuses: %{},
+        files: %{"master" => %{"bors.toml" => delegation_toml()}}
+      }
+    })
+
+    {:ok, user} =
+      Repo.insert(%BorsNG.Database.User{user_xref: 1, is_admin: true, login: "repo_owner"})
+
+    {:ok, delegate} =
+      Repo.insert(%BorsNG.Database.User{user_xref: 2, is_admin: false, login: "pr_author"})
+
+    {:ok, patch} =
+      Repo.insert(%BorsNG.Database.Patch{
+        project_id: proj.id,
+        pr_xref: 1,
+        commit: "N",
+        into_branch: "master",
+        open: true,
+        bundle_reviewer: "pr_author"
+      })
+
+    Repo.insert(%BorsNG.Database.LinkUserProject{
+      user_id: user.id,
+      project_id: proj.id
+    })
+
+    Repo.insert!(%BorsNG.Database.UserPatchDelegation{
+      user_id: delegate.id,
+      patch_id: patch.id
+    })
+
+    user
+  end
+
+  defp mock_comments(pr_xref) do
+    GitHub.ServerMock.get_state()
+    |> get_in([{{:installation, 91}, 14}, :comments, pr_xref])
+  end
+
+  test "delegate- notes a held approval by a removed delegate", %{proj: proj} do
+    user = undelegate_note_setup(proj)
+
+    c = %Command{
+      project: proj,
+      commenter: user,
+      comment: "bors delegate-",
+      pr_xref: 1
+    }
+
+    Command.run(c)
+
+    assert [] == Repo.all(BorsNG.Database.UserPatchDelegation)
+    assert Enum.any?(mock_comments(1), &String.contains?(&1, "All delegations have been removed"))
+    assert Enum.any?(mock_comments(1), &String.contains?(&1, "still counts"))
+    assert Enum.any?(mock_comments(1), &String.contains?(&1, "bors r-"))
+  end
+
+  test "delegate-= notes the removed delegate's held approval", %{proj: proj} do
+    user = undelegate_note_setup(proj)
+
+    c = %Command{
+      project: proj,
+      commenter: user,
+      comment: "bors d-=pr_author",
+      pr_xref: 1
+    }
+
+    Command.run(c)
+
+    assert [] == Repo.all(BorsNG.Database.UserPatchDelegation)
+    assert Enum.any?(mock_comments(1), &String.contains?(&1, "no longer delegated to pr_author"))
+    assert Enum.any?(mock_comments(1), &String.contains?(&1, "still counts"))
+  end
+
+  test "delegate- has no held-approval note when nothing is held", %{proj: proj} do
+    user = undelegate_note_setup(proj)
+
+    # Clear the held approval; the delegation alone must not trigger the note.
+    Repo.get_by!(BorsNG.Database.Patch, pr_xref: 1, project_id: proj.id)
+    |> BorsNG.Database.Patch.changeset(%{bundle_reviewer: nil})
+    |> Repo.update!()
+
+    c = %Command{
+      project: proj,
+      commenter: user,
+      comment: "bors delegate-",
+      pr_xref: 1
+    }
+
+    Command.run(c)
+
+    assert Enum.any?(mock_comments(1), &String.contains?(&1, "All delegations have been removed"))
+    refute Enum.any?(mock_comments(1), &String.contains?(&1, "still counts"))
+  end
+
   test "retry fails for non-members", %{proj: proj} do
     pr = %BorsNG.GitHub.Pr{
       number: 1,

--- a/test/delegation_test.exs
+++ b/test/delegation_test.exs
@@ -1,8 +1,10 @@
 defmodule BorsNG.Database.Context.DelegationTest do
   use ExUnit.Case
 
+  alias BorsNG.Database.Batch
   alias BorsNG.Database.Context.Delegation
   alias BorsNG.Database.Installation
+  alias BorsNG.Database.LinkPatchBatch
   alias BorsNG.Database.Patch
   alias BorsNG.Database.Project
   alias BorsNG.Database.Repo
@@ -106,6 +108,62 @@ defmodule BorsNG.Database.Context.DelegationTest do
       assert [] == Repo.all(UserPatchDelegation)
       assert Enum.any?(comments(), &String.contains?(&1, "Delegation for @alice"))
       assert Enum.any?(comments(), &String.contains?(&1, "expired"))
+      # No standing approval, so no note claiming one survives.
+      refute Enum.any?(comments(), &String.contains?(&1, "still counts"))
+    end
+
+    test "expired notice says a held bundle approval still counts", %{
+      user: user,
+      patch: patch
+    } do
+      patch
+      |> Patch.changeset(%{bundle_reviewer: "alice"})
+      |> Repo.update!()
+
+      past =
+        NaiveDateTime.utc_now()
+        |> NaiveDateTime.add(-3600, :second)
+        |> NaiveDateTime.truncate(:second)
+
+      Repo.insert!(%UserPatchDelegation{
+        user_id: user.id,
+        patch_id: patch.id,
+        expires_at: past,
+        delegated_at_commit: "abc"
+      })
+
+      Delegation.sweep()
+
+      assert [] == Repo.all(UserPatchDelegation)
+      assert Enum.any?(comments(), &String.contains?(&1, "expired"))
+      assert Enum.any?(comments(), &String.contains?(&1, "still counts"))
+      assert Enum.any?(comments(), &String.contains?(&1, "bors r-"))
+    end
+
+    test "expired notice has no note when the held approval is someone else's", %{
+      user: user,
+      patch: patch
+    } do
+      patch
+      |> Patch.changeset(%{bundle_reviewer: "bob"})
+      |> Repo.update!()
+
+      past =
+        NaiveDateTime.utc_now()
+        |> NaiveDateTime.add(-3600, :second)
+        |> NaiveDateTime.truncate(:second)
+
+      Repo.insert!(%UserPatchDelegation{
+        user_id: user.id,
+        patch_id: patch.id,
+        expires_at: past,
+        delegated_at_commit: "abc"
+      })
+
+      Delegation.sweep()
+
+      assert Enum.any?(comments(), &String.contains?(&1, "expired"))
+      refute Enum.any?(comments(), &String.contains?(&1, "still counts"))
     end
 
     test "removes the delegated label when the last delegation expires", %{
@@ -219,6 +277,80 @@ defmodule BorsNG.Database.Context.DelegationTest do
 
       assert Enum.any?(comments(), &String.contains?(&1, "expires"))
       assert Enum.any?(comments(), &String.contains?(&1, "@alice"))
+      # No standing approval, so the warning should not mention one.
+      refute Enum.any?(comments(), &String.contains?(&1, "existing approval"))
+    end
+
+    test "24h warning notes a standing approval queued in a batch", %{
+      proj: proj,
+      user: user,
+      patch: patch
+    } do
+      batch =
+        Repo.insert!(%Batch{
+          project_id: proj.id,
+          into_branch: "master",
+          state: :waiting,
+          last_polled: 0
+        })
+
+      Repo.insert!(%LinkPatchBatch{
+        batch_id: batch.id,
+        patch_id: patch.id,
+        reviewer: "alice"
+      })
+
+      soon =
+        NaiveDateTime.utc_now()
+        |> NaiveDateTime.add(3600, :second)
+        |> NaiveDateTime.truncate(:second)
+
+      Repo.insert!(%UserPatchDelegation{
+        user_id: user.id,
+        patch_id: patch.id,
+        expires_at: soon
+      })
+
+      Delegation.sweep()
+
+      assert Enum.any?(comments(), &String.contains?(&1, "existing approval is not affected"))
+      assert Enum.any?(comments(), &String.contains?(&1, "fresh delegation"))
+    end
+
+    test "24h warning has no note when the batch is already complete", %{
+      proj: proj,
+      user: user,
+      patch: patch
+    } do
+      batch =
+        Repo.insert!(%Batch{
+          project_id: proj.id,
+          into_branch: "master",
+          state: :ok,
+          last_polled: 0
+        })
+
+      Repo.insert!(%LinkPatchBatch{
+        batch_id: batch.id,
+        patch_id: patch.id,
+        reviewer: "alice"
+      })
+
+      soon =
+        NaiveDateTime.utc_now()
+        |> NaiveDateTime.add(3600, :second)
+        |> NaiveDateTime.truncate(:second)
+
+      Repo.insert!(%UserPatchDelegation{
+        user_id: user.id,
+        patch_id: patch.id,
+        expires_at: soon
+      })
+
+      Delegation.sweep()
+
+      assert Enum.any?(comments(), &String.contains?(&1, "expires"))
+      refute Enum.any?(comments(), &String.contains?(&1, "existing approval"))
     end
 
     test "does not warn twice on the same delegation", %{user: user, patch: patch} do


### PR DESCRIPTION
An `r+` granted under a delegation produces a **standing approval**: a queued batch (unbundled), or an approval held for a bundle until the rest is approved (`bundle_reviewer`). Delegation expiry and `bors delegate-` deliberately never withdraw it — the merge-time gate already ran when the `r+` was issued, and the push-based invalidation path drops the approval itself via batch cancel / `drop_held_approval`, so it cannot race the hold.

But the comments bors posted contradicted that: the expiry notice and `delegate-` acknowledgments implied the approval was void, and the pre-expiry warnings implied it was at risk. This PR documents the rule and fixes the comments.

- **`DELEGATION_INVALIDATION.md`** gains an "After approval — standing approvals are not re-checked" section stating the rule (expiry or revocation never voids a standing approval; it only blocks future approvals) and why it's safe, with pointers from the `DelegationInvalidator` moduledoc, `Bundles.hold_approval/2`, and the merge-time gate comment in `command.ex`.
- **Expired notice and `delegate-`/`delegate-=` acks**: when the affected user's approval stands, append that it still counts and that a reviewer can retract it with `bors r-`.
- **Pre-expiry warnings** (week/day tiers): tell an already-approved delegate that only *future* approvals need the delegation — their approval survives expiry, but if it's dropped (new push, `bors r-`, or a failed build), re-approving will need a fresh delegation. This is why the warnings aren't simply suppressed once approved: CI failing after expiry would otherwise strand the PR with no warning ever given.
- New `Context.Delegation.standing_approval?/2` backs the conditional notes; messages only change when a standing approval actually exists, so the common non-approved case is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)