### PR TITLE
feat(web): show bundles on the dashboard and add a bundle detail page

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -406,6 +406,44 @@ table tr.exp:target {
   border-radius: 16px;
   font-size: 16px;
 }
+/* Bundles (bors link / bors stack) */
+.bundle-state {
+  font-size: 16px;
+  font-weight: normal;
+  color: #666;
+  margin-top: 2px;
+}
+.bundle-chip {
+  display: inline-block;
+  font-size: 12px;
+  line-height: 1;
+  padding: 3px 5px;
+  border: 1px solid #3A5883;
+  color: #3A5883;
+  white-space: nowrap;
+  vertical-align: 1px;
+}
+a.bundle-chip:hover, a.bundle-chip:focus {
+  background: #3A5883;
+  color: #fff;
+  text-decoration: none;
+}
+/* Continuous stripe bracketing bundle-mates inside a batch */
+tr.row--bundled > td:first-child {
+  box-shadow: inset 3px 0 0 #3A5883;
+}
+/* A stacked pull request points up at its base on the line above,
+   the way a commit points at its parent */
+.stack-mark {
+  color: #666;
+  padding-right: 2px;
+}
+.approval--held {
+  color: #3c763d;
+}
+.approval--waiting {
+  color: #666;
+}
 /* Allow preformatted text to wrap (crash reports) */
 pre {
   white-space: pre-wrap;
@@ -461,5 +499,22 @@ time[title] {
   }
   .header-link {
       color:#aaa;
+  }
+  .bundle-chip {
+      color:#7da2d4;
+      border-color:#7da2d4;
+  }
+  a.bundle-chip:hover, a.bundle-chip:focus {
+      background:#7da2d4;
+      color:#111;
+  }
+  tr.row--bundled > td:first-child {
+      box-shadow:inset 3px 0 0 #7da2d4;
+  }
+  .bundle-state, .stack-mark, .approval--waiting {
+      color:#999;
+  }
+  .approval--held {
+      color:#7bbf82;
   }
 }

--- a/lib/web/bundle_display.ex
+++ b/lib/web/bundle_display.ex
@@ -1,0 +1,108 @@
+defmodule BorsNG.BundleDisplay do
+  @moduledoc """
+  Display ordering and state for bundles (`bors link` / `bors stack`) in
+  the web UI. Pure functions over already-loaded `Patch` structs; no
+  database or GitHub access.
+  """
+
+  alias BorsNG.Database.Patch
+  alias BorsNG.Worker.Batcher.Bundles
+
+  @doc """
+  Whether any member is stacked on another. A stacked bundle displays in
+  stack order; a plain linked one keeps the page's descending PR order.
+  """
+  def stacked?(members) do
+    Enum.any?(members, &(not is_nil(&1.stacked_on_id)))
+  end
+
+  @doc """
+  Members in display order: each stack base first, its stacked pull
+  requests on the following lines, and everything unstacked in descending
+  PR order. Members on a broken chain (a cycle, or a base that left the
+  bundle) fall back to descending PR order at the end.
+  """
+  def display_order(members) do
+    ids = MapSet.new(members, & &1.id)
+
+    {roots, rest} =
+      Enum.split_with(
+        members,
+        &(is_nil(&1.stacked_on_id) or not MapSet.member?(ids, &1.stacked_on_id))
+      )
+
+    by_base = Enum.group_by(rest, & &1.stacked_on_id)
+
+    ordered =
+      roots
+      |> Enum.sort_by(& &1.pr_xref, :desc)
+      |> Enum.flat_map(&chain(&1, by_base))
+
+    ordered_ids = MapSet.new(ordered, & &1.id)
+
+    leftover =
+      members
+      |> Enum.reject(&MapSet.member?(ordered_ids, &1.id))
+      |> Enum.sort_by(& &1.pr_xref, :desc)
+
+    ordered ++ leftover
+  end
+
+  defp chain(patch, by_base) do
+    stacked =
+      by_base
+      |> Map.get(patch.id, [])
+      |> Enum.sort_by(& &1.pr_xref, :desc)
+      |> Enum.flat_map(&chain(&1, by_base))
+
+    [patch | stacked]
+  end
+
+  @doc """
+  The display state of a bundle that is not fully batched:
+
+    * `{:blocked, patch}` — a member is closed or a draft
+    * `{:waiting_on, patches}` — open members still needing `r+`
+    * `:ready` — every member is approved
+  """
+  def state(members) do
+    case Bundles.unapproved(members) do
+      [] ->
+        :ready
+
+      unapproved ->
+        case Enum.find(unapproved, &(&1.open == false or &1.is_draft)) do
+          nil -> {:waiting_on, unapproved}
+          blocker -> {:blocked, blocker}
+        end
+    end
+  end
+
+  @doc """
+  Why a blocked member blocks: it is closed, or it is a draft.
+  """
+  def blocker_reason(%Patch{open: false}), do: "closed"
+  def blocker_reason(%Patch{}), do: "a draft"
+
+  @doc """
+  A batch's patches in display order: descending PR order, except bundle
+  members stay together (sorted by their highest member) with stacks base
+  first.
+  """
+  def batch_display_order(patches) do
+    {bundled, singles} = Enum.split_with(patches, & &1.bundle_id)
+
+    bundle_groups =
+      bundled
+      |> Enum.group_by(& &1.bundle_id)
+      |> Enum.map(fn {_id, members} ->
+        {members |> Enum.map(& &1.pr_xref) |> Enum.max(), display_order(members)}
+      end)
+
+    single_groups = Enum.map(singles, &{&1.pr_xref, [&1]})
+
+    (bundle_groups ++ single_groups)
+    |> Enum.sort_by(&elem(&1, 0), :desc)
+    |> Enum.flat_map(&elem(&1, 1))
+  end
+end

--- a/lib/web/controllers/admin_controller.ex
+++ b/lib/web/controllers/admin_controller.ex
@@ -69,15 +69,20 @@ defmodule BorsNG.AdminController do
     redirect(conn, to: admin_path(conn, :index))
   end
 
-  def crashes(conn, %{"days" => days}) do
-    crashes =
-      days
-      |> String.to_integer(10)
-      |> Crash.days()
-      |> preload([c], [:project])
-      |> order_by([c], desc: c.inserted_at)
-      |> Repo.all()
+  def crashes(conn, params) do
+    case Integer.parse(params["days"] || "") do
+      {days, ""} ->
+        crashes =
+          days
+          |> Crash.days()
+          |> preload([c], [:project])
+          |> order_by([c], desc: c.inserted_at)
+          |> Repo.all()
 
-    render(conn, "crashes.html", crashes: crashes, days: days)
+        render(conn, "crashes.html", crashes: crashes, days: days)
+
+      _ ->
+        send_resp(conn, 400, "The days parameter must be an integer.")
+    end
   end
 end

--- a/lib/web/controllers/batch_controller.ex
+++ b/lib/web/controllers/batch_controller.ex
@@ -14,7 +14,7 @@ defmodule BorsNG.BatchController do
   alias BorsNG.Database.Status
 
   def show(conn, %{"id" => id}) do
-    batch = Repo.get(Batch, id)
+    batch = Repo.get!(Batch, id)
     project = Repo.get(Project, batch.project_id)
 
     patches = Repo.all(Patch.all_for_batch(batch.id))

--- a/lib/web/controllers/bundle_controller.ex
+++ b/lib/web/controllers/bundle_controller.ex
@@ -17,57 +17,44 @@ defmodule BorsNG.BundleController do
   alias BorsNG.Database.UserPatchDelegation
 
   def show(conn, %{"id" => id}) do
-    case Repo.get(PatchBundle, id) do
-      nil ->
-        render(conn, "show.html",
-          bundle: nil,
-          project: nil,
-          members: [],
-          state: nil,
-          stacked: false,
-          batches: [],
-          delegations: %{}
-        )
+    bundle = Repo.get!(PatchBundle, id)
+    project = Repo.get(Project, bundle.project_id)
 
-      bundle ->
-        project = Repo.get(Project, bundle.project_id)
+    members =
+      bundle.id
+      |> Patch.all_for_bundle()
+      |> Repo.all()
 
-        members =
-          bundle.id
-          |> Patch.all_for_bundle()
-          |> Repo.all()
+    batches =
+      from(b in Batch,
+        join: l in LinkPatchBatch,
+        on: l.batch_id == b.id,
+        join: p in Patch,
+        on: p.id == l.patch_id,
+        where: p.bundle_id == ^bundle.id,
+        distinct: true,
+        order_by: [desc: b.id]
+      )
+      |> Repo.all()
 
-        batches =
-          from(b in Batch,
-            join: l in LinkPatchBatch,
-            on: l.batch_id == b.id,
-            join: p in Patch,
-            on: p.id == l.patch_id,
-            where: p.bundle_id == ^bundle.id,
-            distinct: true,
-            order_by: [desc: b.id]
-          )
-          |> Repo.all()
+    delegations =
+      from(upd in UserPatchDelegation,
+        join: u in User,
+        on: u.id == upd.user_id,
+        where: upd.patch_id in ^Enum.map(members, & &1.id),
+        select: {upd.patch_id, u.login}
+      )
+      |> Repo.all()
+      |> Enum.group_by(&elem(&1, 0), &elem(&1, 1))
 
-        delegations =
-          from(upd in UserPatchDelegation,
-            join: u in User,
-            on: u.id == upd.user_id,
-            where: upd.patch_id in ^Enum.map(members, & &1.id),
-            select: {upd.patch_id, u.login}
-          )
-          |> Repo.all()
-          |> Enum.group_by(&elem(&1, 0), &elem(&1, 1))
-
-        render(conn, "show.html",
-          bundle: bundle,
-          project: project,
-          members: BundleDisplay.display_order(members),
-          state: BundleDisplay.state(members),
-          stacked: BundleDisplay.stacked?(members),
-          batches: batches,
-          delegations: delegations
-        )
-    end
+    render(conn, "show.html",
+      bundle: bundle,
+      project: project,
+      members: BundleDisplay.display_order(members),
+      state: BundleDisplay.state(members),
+      stacked: BundleDisplay.stacked?(members),
+      batches: batches,
+      delegations: delegations
+    )
   end
 end

--- a/lib/web/controllers/bundle_controller.ex
+++ b/lib/web/controllers/bundle_controller.ex
@@ -1,0 +1,73 @@
+defmodule BorsNG.BundleController do
+  @moduledoc """
+  The bundle detail page: the members of one `bors link` / `bors stack`
+  bundle, their approval state, and the batches they have entered.
+  """
+
+  use BorsNG.Web, :controller
+
+  alias BorsNG.BundleDisplay
+  alias BorsNG.Database.Batch
+  alias BorsNG.Database.LinkPatchBatch
+  alias BorsNG.Database.Patch
+  alias BorsNG.Database.PatchBundle
+  alias BorsNG.Database.Project
+  alias BorsNG.Database.Repo
+  alias BorsNG.Database.User
+  alias BorsNG.Database.UserPatchDelegation
+
+  def show(conn, %{"id" => id}) do
+    case Repo.get(PatchBundle, id) do
+      nil ->
+        render(conn, "show.html",
+          bundle: nil,
+          project: nil,
+          members: [],
+          state: nil,
+          stacked: false,
+          batches: [],
+          delegations: %{}
+        )
+
+      bundle ->
+        project = Repo.get(Project, bundle.project_id)
+
+        members =
+          bundle.id
+          |> Patch.all_for_bundle()
+          |> Repo.all()
+
+        batches =
+          from(b in Batch,
+            join: l in LinkPatchBatch,
+            on: l.batch_id == b.id,
+            join: p in Patch,
+            on: p.id == l.patch_id,
+            where: p.bundle_id == ^bundle.id,
+            distinct: true,
+            order_by: [desc: b.id]
+          )
+          |> Repo.all()
+
+        delegations =
+          from(upd in UserPatchDelegation,
+            join: u in User,
+            on: u.id == upd.user_id,
+            where: upd.patch_id in ^Enum.map(members, & &1.id),
+            select: {upd.patch_id, u.login}
+          )
+          |> Repo.all()
+          |> Enum.group_by(&elem(&1, 0), &elem(&1, 1))
+
+        render(conn, "show.html",
+          bundle: bundle,
+          project: project,
+          members: BundleDisplay.display_order(members),
+          state: BundleDisplay.state(members),
+          stacked: BundleDisplay.stacked?(members),
+          batches: batches,
+          delegations: delegations
+        )
+    end
+  end
+end

--- a/lib/web/controllers/project_controller.ex
+++ b/lib/web/controllers/project_controller.ex
@@ -11,6 +11,7 @@ defmodule BorsNG.ProjectController do
 
   use BorsNG.Web, :controller
 
+  alias BorsNG.BundleDisplay
   alias BorsNG.Worker.Batcher
   alias BorsNG.Database.Context.Dashboard
   alias BorsNG.Database.Context.Permission
@@ -90,10 +91,34 @@ defmodule BorsNG.ProjectController do
     %{
       id: batch.id,
       commit: batch.commit,
-      patches: Repo.all(Patch.all_for_batch(batch.id)),
+      patches:
+        batch.id
+        |> Patch.all_for_batch()
+        |> Repo.all()
+        |> BundleDisplay.batch_display_order(),
       priority: batch.priority,
       state: batch.state
     }
+  end
+
+  # One group per bundle that still has an unbatched member: the full
+  # membership (closed members included, so a blocked bundle can say why),
+  # in display order, with the derived group state.
+  defp bundle_groups([]), do: []
+
+  defp bundle_groups(bundle_ids) do
+    from(p in Patch, where: p.bundle_id in ^bundle_ids)
+    |> Repo.all()
+    |> Enum.group_by(& &1.bundle_id)
+    |> Enum.map(fn {id, members} ->
+      %{
+        id: id,
+        members: BundleDisplay.display_order(members),
+        state: BundleDisplay.state(members),
+        stacked: BundleDisplay.stacked?(members)
+      }
+    end)
+    |> Enum.sort_by(& &1.id, :desc)
   end
 
   def show(conn, mode, project, _params) do
@@ -138,6 +163,17 @@ defmodule BorsNG.ProjectController do
       |> Enum.reject(fn {_patch_id, user, _exp} -> is_nil(user) end)
       |> Enum.group_by(&elem(&1, 0), fn {_pid, u, exp} -> %{user: u, expires_at: exp} end)
 
+    # Bundled patches display in their own per-bundle groups, not in the
+    # Delegated / Awaiting review sections.
+    {bundled_patches, unbatched_patches} =
+      Enum.split_with(unbatched_patches, & &1.bundle_id)
+
+    bundles =
+      bundled_patches
+      |> Enum.map(& &1.bundle_id)
+      |> Enum.uniq()
+      |> bundle_groups()
+
     {delegated_patches, undelegated_patches} =
       unbatched_patches
       |> Enum.split_with(&Map.get(patch_users_map, &1.id))
@@ -151,6 +187,7 @@ defmodule BorsNG.ProjectController do
     render(conn, "show.html",
       project: project,
       batches: batches,
+      bundles: bundles,
       trying_attempts: trying_attempts,
       waiting_attempts: waiting_attempts,
       is_synchronizing: is_synchronizing,

--- a/lib/web/router.ex
+++ b/lib/web/router.ex
@@ -57,6 +57,14 @@ defmodule BorsNG.Router do
     get("/:id", BatchController, :show)
   end
 
+  scope "/bundles", BorsNG do
+    pipe_through(:browser_page)
+    pipe_through(:browser_session)
+    pipe_through(:browser_login)
+
+    get("/:id", BundleController, :show)
+  end
+
   scope "/repositories", BorsNG do
     pipe_through(:browser_page)
     pipe_through(:browser_session)

--- a/lib/web/templates/bundle/show.html.eex
+++ b/lib/web/templates/bundle/show.html.eex
@@ -19,7 +19,6 @@
 
 <main role=main><div class=wrapper>
 
-<%= if @bundle do %>
 <p>Date: <%= htmlify_naive_datetime(@bundle.inserted_at) %></p>
 <p>State: <%= render(BorsNG.ProjectView, "_bundle_state.html", state: @state, project: @project) %></p>
 <p>Pull requests<%= if @stacked do %> (stack order)<% end %>:</p>
@@ -53,9 +52,5 @@
   <% end %>
   <% end %>
 </ul>
-
-<% else %>
-There is no such bundle
-<% end %>
 
 </div></main>

--- a/lib/web/templates/bundle/show.html.eex
+++ b/lib/web/templates/bundle/show.html.eex
@@ -1,0 +1,61 @@
+<nav>
+
+<div class=wrapper>
+  <%= if @project do %>
+  <a href="<%= Confex.fetch_env!(:bors, :html_github_root) %>/<%= @project.name %>/">
+    <%= @project.name %>
+  </a>
+  ›
+  <a href="<%= project_path(@conn, :show, @project) %>">
+    Pull requests
+  </a>
+  <% end %>
+  <h1>
+  Bundle Details
+  </h1>
+</div>
+
+</nav>
+
+<main role=main><div class=wrapper>
+
+<%= if @bundle do %>
+<p>Date: <%= htmlify_naive_datetime(@bundle.inserted_at) %></p>
+<p>State: <%= render(BorsNG.ProjectView, "_bundle_state.html", state: @state, project: @project) %></p>
+<p>Pull requests<%= if @stacked do %> (stack order)<% end %>:</p>
+<% xrefs = Map.new(@members, &{&1.id, &1.pr_xref}) %>
+<ul>
+  <%= for patch <- @members do %>
+  <li>
+    <%= if patch.stacked_on_id && xrefs[patch.stacked_on_id] do %><span class=stack-mark title="Stacked on #<%= xrefs[patch.stacked_on_id] %>">↰</span><% end %>
+    <a href="<%= Confex.fetch_env!(:bors, :html_github_root) %>/<%= @project.name %>/pull/<%= patch.pr_xref %>">#<%= patch.pr_xref %></a>
+    —
+    <%= cond do %>
+    <% not patch.open -> %>
+    <span class=span--error>closed</span>
+    <% patch.is_draft -> %>
+    <span class=span--error>draft</span>
+    <% patch.bundle_reviewer -> %>
+    <span class=approval--held>✓ held (<%= patch.bundle_reviewer %>)</span>
+    <% true -> %>
+    <span class=approval--waiting>waiting<%= if logins = Map.get(@delegations, patch.id) do %> — delegated to <%= Enum.join(logins, ", ") %><% end %></span>
+    <% end %>
+  </li>
+  <% end %>
+</ul>
+<p>Batches:</p>
+<ul>
+  <%= if @batches == [] do %>
+  <li>None</li>
+  <% else %>
+  <%= for batch <- @batches do %>
+  <li><a href="/batches/<%= batch.id %>">Batch <%= batch.id %></a> (<%= stringify_state(batch.state) %>)</li>
+  <% end %>
+  <% end %>
+</ul>
+
+<% else %>
+There is no such bundle
+<% end %>
+
+</div></main>

--- a/lib/web/templates/project/_bundle_state.html.eex
+++ b/lib/web/templates/project/_bundle_state.html.eex
@@ -1,0 +1,8 @@
+<%= case @state do %>
+<% {:blocked, blocker} -> %>
+<span class=span--error>Blocked</span>: <a href="<%= Confex.fetch_env!(:bors, :html_github_root) %>/<%= @project.name %>/pull/<%= blocker.pr_xref %>">#<%= blocker.pr_xref %></a> is <%= BorsNG.BundleDisplay.blocker_reason(blocker) %>
+<% {:waiting_on, pending} -> %>
+Waiting for approval of <%= for {patch, i} <- Enum.with_index(pending) do %><%= if i > 0 do %>, <% end %><a href="<%= Confex.fetch_env!(:bors, :html_github_root) %>/<%= @project.name %>/pull/<%= patch.pr_xref %>">#<%= patch.pr_xref %></a><% end %>
+<% :ready -> %>
+Waiting to run
+<% end %>

--- a/lib/web/templates/project/show.html.eex
+++ b/lib/web/templates/project/show.html.eex
@@ -18,7 +18,7 @@
 <main role=main><div class=wrapper>
 
 <%= if empty?(@undelegated_patches) and empty?(@delegated_patches) and empty?(@batches) and
-       empty?(@trying_attempts) and empty?(@waiting_attempts) do %>
+       empty?(@bundles) and empty?(@trying_attempts) and empty?(@waiting_attempts) do %>
   Nothing to see here
 <% else %>
 <table class="table">
@@ -35,10 +35,11 @@
     <tr role=row><th>#</th><th aria-label=Mergeable title=Mergeable>M<span class=hide-on-narrow>ergeable</span></th><th>Title</th><th aria-label="Delegated to" title="Delegated to">D<span class=hide-on-narrow>elegated to</span></th><th class=priority-column>Priority</th><th class=hide-on-super-narrow>Commit</th></tr>
   </thead>
   <tbody>
+  <% xrefs = Map.new(batch.patches, &{&1.id, &1.pr_xref}) %>
   <%= for patch <- batch.patches do %>
-    <tr role="row" id="prrow-<%= patch.pr_xref %>">
+    <tr role="row" id="prrow-<%= patch.pr_xref %>"<%= if patch.bundle_id do %> class=row--bundled<% end %>>
       <td class=expand-row>
-        <%= patch.pr_xref %>
+        <%= patch.pr_xref %><%= if patch.bundle_id do %> <a class=bundle-chip href="../bundles/<%= patch.bundle_id %>" title="Bundle <%= patch.bundle_id %> — merges atomically">⛓ <%= patch.bundle_id %></a><% end %>
       </td>
       <td class=span--<%= if patch.is_mergeable do %>ok<% else %>error<% end %> aria-label="<%= if patch.is_mergeable do %><%= if patch.is_draft do %>Draft<% else %>Yes<% end %><% else %>No<% end %>" title="<%= if patch.is_mergeable do %><%= if patch.is_draft do %>Draft<% else %>Yes<% end %><% else %>No<% end %>">
         <%= if patch.is_mergeable do %>
@@ -53,12 +54,67 @@
       </td>
       <td class="fill-link">
         <a href="<%= Confex.fetch_env!(:bors, :html_github_root) %>/<%= @project.name %>/pull/<%= patch.pr_xref %>">
-          <%= patch.title %>
+          <%= if patch.stacked_on_id && xrefs[patch.stacked_on_id] do %><span class=stack-mark title="Stacked on #<%= xrefs[patch.stacked_on_id] %>">↰</span><% end %><%= patch.title %>
         </a>
       </td>
       <td class=delegated-cell>
         <%= Map.get(@patch_users_map, patch.id, []) |> format_delegations() %>
       </td>
+      <td class=priority-cell>
+        <%= patch.priority %>
+        <%= if patch.is_single do %>S<% end %>
+      </td>
+      <td class=hide-on-super-narrow>
+        <code><%= truncate_commit(patch.commit) %></code>
+      </td>
+    </tr>
+  <% end %>
+  </tbody>
+<% end %>
+<%= for bundle <- @bundles do %>
+  <% xrefs = Map.new(bundle.members, &{&1.id, &1.pr_xref}) %>
+  <thead>
+    <tr role=heading><td aria-role=presentation colspan=6>
+      <a href="../bundles/<%= bundle.id %>">Bundle <%= bundle.id %></a>
+      <h2 class=header>
+        <%= if bundle.stacked do %>Stacked<% else %>Linked<% end %>
+        <span class=header-count><%= Enum.count(bundle.members) %></span>
+      </h2>
+      <div class=bundle-state><%= render("_bundle_state.html", state: bundle.state, project: @project) %></div>
+    </td></tr>
+    <tr role=row><th>#</th><th aria-label=Mergeable title=Mergeable>M<span class=hide-on-narrow>ergeable</span></th><th>Title</th><th aria-label=Approval title=Approval>A<span class=hide-on-narrow>pproval</span></th><th class=priority-column>Priority</th><th class=hide-on-super-narrow>Commit</th></tr>
+  </thead>
+  <tbody>
+  <%= for patch <- bundle.members do %>
+    <tr role="row" id="prrow-<%= patch.pr_xref %>">
+      <td class=expand-row>
+        <%= patch.pr_xref %>
+      </td>
+      <%= if patch.open do %>
+      <td class=span--<%= if patch.is_mergeable do %>ok<% else %>error<% end %> aria-label="<%= if patch.is_mergeable do %><%= if patch.is_draft do %>Draft<% else %>Yes<% end %><% else %>No<% end %>" title="<%= if patch.is_mergeable do %><%= if patch.is_draft do %>Draft<% else %>Yes<% end %><% else %>No<% end %>">
+        <%= if patch.is_mergeable do %>
+            <%= if patch.is_draft do %>
+            ✎<span class=hide-on-narrow> Draft</span>
+            <% else %>
+            ✓<span class=hide-on-narrow> Yes</span>
+            <% end %>
+        <% else %>
+            ⚠<span class=hide-on-narrow> No</span>
+        <% end %>
+      </td>
+      <% else %>
+      <td class=span--error aria-label=Closed title=Closed>✗<span class=hide-on-narrow> Closed</span></td>
+      <% end %>
+      <td class="fill-link">
+        <a href="<%= Confex.fetch_env!(:bors, :html_github_root) %>/<%= @project.name %>/pull/<%= patch.pr_xref %>">
+          <%= if patch.stacked_on_id && xrefs[patch.stacked_on_id] do %><span class=stack-mark title="Stacked on #<%= xrefs[patch.stacked_on_id] %>">↰</span><% end %><%= patch.title %>
+        </a>
+      </td>
+      <%= if patch.bundle_reviewer do %>
+      <td class=approval--held>✓ held<span class=hide-on-narrow> (<%= patch.bundle_reviewer %>)</span></td>
+      <% else %>
+      <td class=approval--waiting>waiting<%= if users = Map.get(@patch_users_map, patch.id) do %><span class=hide-on-narrow> — delegated to <%= format_delegations(users) %></span><% end %></td>
+      <% end %>
       <td class=priority-cell>
         <%= patch.priority %>
         <%= if patch.is_single do %>S<% end %>

--- a/lib/web/views/bundle_view.ex
+++ b/lib/web/views/bundle_view.ex
@@ -1,0 +1,23 @@
+defmodule BorsNG.BundleView do
+  @moduledoc """
+  Bundle details page
+  """
+
+  use BorsNG.Web, :view
+
+  def stringify_state(state) do
+    case state do
+      :waiting -> "Waiting to run"
+      :running -> "Running"
+      :ok -> "Succeeded"
+      :error -> "Failed"
+      :canceled -> "Canceled"
+      _ -> "Invalid"
+    end
+  end
+
+  def htmlify_naive_datetime(datetime) do
+    ["<time class=time-convert>", NaiveDateTime.to_iso8601(datetime), "+00:00</time>"]
+    |> Phoenix.HTML.raw()
+  end
+end

--- a/test/bundle_display_test.exs
+++ b/test/bundle_display_test.exs
@@ -1,0 +1,108 @@
+defmodule BorsNG.BundleDisplayTest do
+  use ExUnit.Case, async: true
+
+  alias BorsNG.BundleDisplay
+  alias BorsNG.Database.Patch
+
+  defp patch(id, xref, opts \\ []) do
+    %Patch{
+      id: id,
+      pr_xref: xref,
+      bundle_id: Keyword.get(opts, :bundle_id, 1),
+      stacked_on_id: Keyword.get(opts, :stacked_on),
+      bundle_reviewer: Keyword.get(opts, :reviewer),
+      open: Keyword.get(opts, :open, true),
+      is_draft: Keyword.get(opts, :draft, false)
+    }
+  end
+
+  describe "stacked?/1" do
+    test "true when any member is stacked" do
+      assert BundleDisplay.stacked?([patch(1, 10), patch(2, 11, stacked_on: 1)])
+    end
+
+    test "false for a plain linked bundle" do
+      refute BundleDisplay.stacked?([patch(1, 10), patch(2, 11)])
+    end
+  end
+
+  describe "display_order/1" do
+    test "a plain linked bundle keeps descending PR order" do
+      members = [patch(1, 10), patch(2, 12), patch(3, 11)]
+
+      assert [12, 11, 10] =
+               members |> BundleDisplay.display_order() |> Enum.map(& &1.pr_xref)
+    end
+
+    test "a stacked bundle lists the base first, then each stacked PR" do
+      base = patch(1, 10)
+      mid = patch(2, 11, stacked_on: 1)
+      top = patch(3, 12, stacked_on: 2)
+
+      assert [10, 11, 12] =
+               [top, base, mid]
+               |> BundleDisplay.display_order()
+               |> Enum.map(& &1.pr_xref)
+    end
+
+    test "members whose base left the bundle become roots" do
+      # 99 is not a member; 11 starts its own chain
+      members = [patch(2, 11, stacked_on: 99), patch(3, 12, stacked_on: 2)]
+
+      assert [11, 12] =
+               members |> BundleDisplay.display_order() |> Enum.map(& &1.pr_xref)
+    end
+
+    test "a cycle falls back to descending PR order" do
+      members = [patch(1, 10, stacked_on: 2), patch(2, 11, stacked_on: 1)]
+
+      assert [11, 10] =
+               members |> BundleDisplay.display_order() |> Enum.map(& &1.pr_xref)
+    end
+  end
+
+  describe "state/1" do
+    test "waiting on the members without a held approval" do
+      held = patch(1, 10, reviewer: "reviewer")
+      pending = patch(2, 11)
+
+      assert {:waiting_on, [%Patch{pr_xref: 11}]} = BundleDisplay.state([held, pending])
+    end
+
+    test "blocked by a draft member" do
+      held = patch(1, 10, reviewer: "reviewer")
+      draft = patch(2, 11, draft: true)
+
+      assert {:blocked, %Patch{pr_xref: 11}} = BundleDisplay.state([held, draft])
+      assert BundleDisplay.blocker_reason(draft) == "a draft"
+    end
+
+    test "blocked by a closed member, even one holding an approval" do
+      held = patch(1, 10, reviewer: "reviewer")
+      closed = patch(2, 11, reviewer: "reviewer", open: false)
+
+      assert {:blocked, %Patch{pr_xref: 11}} = BundleDisplay.state([held, closed])
+      assert BundleDisplay.blocker_reason(closed) == "closed"
+    end
+
+    test "ready when every member holds an approval" do
+      members = [patch(1, 10, reviewer: "a"), patch(2, 11, reviewer: "b")]
+
+      assert :ready = BundleDisplay.state(members)
+    end
+  end
+
+  describe "batch_display_order/1" do
+    test "bundle members stay together, stacks base first" do
+      base = patch(1, 10, bundle_id: 7)
+      top = patch(2, 11, bundle_id: 7, stacked_on: 1)
+      lone_high = patch(3, 12, bundle_id: nil)
+      lone_low = patch(4, 9, bundle_id: nil)
+
+      assert [12, 10, 11, 9] =
+               [lone_low, top, lone_high, base]
+               |> BundleDisplay.batch_display_order()
+               |> Enum.map(& &1.pr_xref)
+    end
+  end
+end

--- a/test/controllers/admin_controller_test.exs
+++ b/test/controllers/admin_controller_test.exs
@@ -1,0 +1,64 @@
+defmodule BorsNG.AdminControllerTest do
+  use BorsNG.ConnCase
+
+  alias BorsNG.Database.Repo
+  alias BorsNG.Database.User
+
+  setup do
+    # The mock GitHub login authenticates as user_xref 23; pre-create that
+    # user as an admin so the requests reach the admin-only routes.
+    user =
+      Repo.insert!(%User{
+        user_xref: 23,
+        login: "ghost",
+        is_admin: true
+      })
+
+    {:ok, user: user}
+  end
+
+  def login(conn) do
+    conn = get(conn, auth_path(conn, :index, "github"))
+    assert html_response(conn, 302) =~ "MOCK_GITHUB_AUTHORIZE_URL"
+
+    conn =
+      get(
+        conn,
+        auth_path(
+          conn,
+          :callback,
+          "github",
+          %{"code" => "MOCK_GITHUB_AUTHORIZE_CODE"}
+        )
+      )
+
+    html_response(conn, 302)
+    conn
+  end
+
+  test "need to log in to see this", %{conn: conn} do
+    conn = get(conn, "/admin/crashes?days=1")
+    assert html_response(conn, 302) =~ "auth"
+  end
+
+  test "shows the crashes for a valid days parameter", %{conn: conn} do
+    conn = login(conn)
+    conn = get(conn, "/admin/crashes?days=7")
+
+    assert html_response(conn, 200) =~ "Crashes in last 7 days"
+  end
+
+  test "returns 400 for a non-integer days parameter", %{conn: conn} do
+    conn = login(conn)
+    conn = get(conn, "/admin/crashes?days=abc")
+
+    assert response(conn, 400)
+  end
+
+  test "returns 400 when the days parameter is missing", %{conn: conn} do
+    conn = login(conn)
+    conn = get(conn, "/admin/crashes")
+
+    assert response(conn, 400)
+  end
+end

--- a/test/controllers/batch_controller_test.exs
+++ b/test/controllers/batch_controller_test.exs
@@ -163,4 +163,12 @@ defmodule BorsNG.BatchControllerTest do
 
     assert html_response(conn, 200) =~ "Batch Details"
   end
+
+  test "returns 404 when there is no such batch", %{conn: conn} do
+    conn = login(conn)
+
+    assert_error_sent(404, fn ->
+      get(conn, "/batches/0")
+    end)
+  end
 end

--- a/test/controllers/bundle_controller_test.exs
+++ b/test/controllers/bundle_controller_test.exs
@@ -117,10 +117,11 @@ defmodule BorsNG.BundleControllerTest do
     refute html =~ "None"
   end
 
-  test "says so when there is no such bundle", %{conn: conn} do
+  test "returns 404 when there is no such bundle", %{conn: conn} do
     conn = login(conn)
-    conn = get(conn, "/bundles/0")
 
-    assert html_response(conn, 200) =~ "There is no such bundle"
+    assert_error_sent(404, fn ->
+      get(conn, "/bundles/0")
+    end)
   end
 end

--- a/test/controllers/bundle_controller_test.exs
+++ b/test/controllers/bundle_controller_test.exs
@@ -1,0 +1,126 @@
+defmodule BorsNG.BundleControllerTest do
+  use BorsNG.ConnCase
+
+  alias BorsNG.Database.Batch
+  alias BorsNG.Database.Installation
+  alias BorsNG.Database.LinkPatchBatch
+  alias BorsNG.Database.Patch
+  alias BorsNG.Database.PatchBundle
+  alias BorsNG.Database.Project
+  alias BorsNG.Database.Repo
+  alias BorsNG.Database.User
+
+  setup do
+    installation =
+      Repo.insert!(%Installation{
+        installation_xref: 31
+      })
+
+    project =
+      Repo.insert!(%Project{
+        installation_id: installation.id,
+        repo_xref: 13,
+        name: "example/project"
+      })
+
+    user =
+      Repo.insert!(%User{
+        user_xref: 23,
+        login: "ghost"
+      })
+
+    bundle = Repo.insert!(%PatchBundle{project_id: project.id})
+
+    base =
+      Repo.insert!(%Patch{
+        project_id: project.id,
+        pr_xref: 43,
+        title: "base patch",
+        bundle_id: bundle.id,
+        bundle_reviewer: "reviewer"
+      })
+
+    stacked =
+      Repo.insert!(%Patch{
+        project_id: project.id,
+        pr_xref: 44,
+        title: "stacked patch",
+        bundle_id: bundle.id,
+        stacked_on_id: base.id
+      })
+
+    {:ok, project: project, user: user, bundle: bundle, base: base, stacked: stacked}
+  end
+
+  test "need to log in to see this", %{conn: conn, bundle: bundle} do
+    conn = get(conn, "/bundles/#{bundle.id}")
+    assert html_response(conn, 302) =~ "auth"
+  end
+
+  def login(conn) do
+    conn = get(conn, auth_path(conn, :index, "github"))
+    assert html_response(conn, 302) =~ "MOCK_GITHUB_AUTHORIZE_URL"
+
+    conn =
+      get(
+        conn,
+        auth_path(
+          conn,
+          :callback,
+          "github",
+          %{"code" => "MOCK_GITHUB_AUTHORIZE_CODE"}
+        )
+      )
+
+    html_response(conn, 302)
+    conn
+  end
+
+  test "shows the members in stack order with their approval state", %{
+    conn: conn,
+    bundle: bundle
+  } do
+    conn = login(conn)
+    conn = get(conn, "/bundles/#{bundle.id}")
+
+    html = html_response(conn, 200)
+    assert html =~ "Bundle Details"
+    assert html =~ "(stack order)"
+    assert html =~ "Waiting for approval of"
+    assert html =~ "#43"
+    assert html =~ "#44"
+    assert html =~ "✓ held (reviewer)"
+    assert html =~ "waiting"
+    assert html =~ "Stacked on #43"
+    assert html =~ "None"
+    # base before stacked
+    assert html =~ ~r/#43.*#44/s
+  end
+
+  test "lists the batches the bundle entered", %{conn: conn, bundle: bundle, project: project} do
+    batch =
+      Repo.insert!(%Batch{
+        project_id: project.id,
+        state: :running
+      })
+
+    for patch <- Repo.all(Patch.all_for_bundle(bundle.id)) do
+      Repo.insert!(%LinkPatchBatch{patch_id: patch.id, batch_id: batch.id})
+    end
+
+    conn = login(conn)
+    conn = get(conn, "/bundles/#{bundle.id}")
+
+    html = html_response(conn, 200)
+    assert html =~ "Batch #{batch.id}"
+    assert html =~ "(Running)"
+    refute html =~ "None"
+  end
+
+  test "says so when there is no such bundle", %{conn: conn} do
+    conn = login(conn)
+    conn = get(conn, "/bundles/0")
+
+    assert html_response(conn, 200) =~ "There is no such bundle"
+  end
+end

--- a/test/controllers/project_controller_test.exs
+++ b/test/controllers/project_controller_test.exs
@@ -7,6 +7,7 @@ defmodule BorsNG.ProjectControllerTest do
   alias BorsNG.Database.LinkPatchBatch
   alias BorsNG.Database.LinkUserProject
   alias BorsNG.Database.Patch
+  alias BorsNG.Database.PatchBundle
   alias BorsNG.Database.Project
   alias BorsNG.Database.Repo
   alias BorsNG.Database.User
@@ -110,6 +111,123 @@ defmodule BorsNG.ProjectControllerTest do
 
     conn = get(conn, project_path(conn, :show, project))
     assert html_response(conn, 200) =~ "Delegated"
+  end
+
+  test "show a stacked bundle in its own group", %{conn: conn, project: project, user: user} do
+    conn = login(conn)
+    Repo.insert!(%LinkUserProject{user_id: user.id, project_id: project.id})
+
+    bundle = Repo.insert!(%PatchBundle{project_id: project.id})
+
+    base =
+      Repo.insert!(%Patch{
+        project_id: project.id,
+        pr_xref: 43,
+        title: "base patch",
+        bundle_id: bundle.id,
+        bundle_reviewer: "reviewer"
+      })
+
+    Repo.insert!(%Patch{
+      project_id: project.id,
+      pr_xref: 44,
+      title: "stacked patch",
+      bundle_id: bundle.id,
+      stacked_on_id: base.id
+    })
+
+    conn = get(conn, project_path(conn, :show, project))
+    html = html_response(conn, 200)
+
+    assert html =~ "Stacked"
+    assert html =~ "Bundle #{bundle.id}"
+    assert html =~ "Waiting for approval of"
+    assert html =~ "✓ held"
+    assert html =~ "Stacked on #43"
+    # base first, then the PR stacked on it
+    assert html =~ ~r/base patch.*stacked patch/s
+    # bundled patches leave the plain sections
+    refute html =~ "Awaiting review"
+    refute html =~ "Delegated"
+  end
+
+  test "show a linked bundle blocked by a draft", %{conn: conn, project: project, user: user} do
+    conn = login(conn)
+    Repo.insert!(%LinkUserProject{user_id: user.id, project_id: project.id})
+
+    bundle = Repo.insert!(%PatchBundle{project_id: project.id})
+
+    Repo.insert!(%Patch{
+      project_id: project.id,
+      pr_xref: 43,
+      title: "ready patch",
+      bundle_id: bundle.id,
+      bundle_reviewer: "reviewer"
+    })
+
+    Repo.insert!(%Patch{
+      project_id: project.id,
+      pr_xref: 44,
+      title: "draft patch",
+      bundle_id: bundle.id,
+      is_draft: true
+    })
+
+    conn = get(conn, project_path(conn, :show, project))
+    html = html_response(conn, 200)
+
+    assert html =~ "Linked"
+    refute html =~ "Stacked"
+    assert html =~ "Blocked"
+    assert html =~ "is a draft"
+    # no stack order: plain descending PR order
+    assert html =~ ~r/draft patch.*ready patch/s
+  end
+
+  test "mark bundled patches inside a batch", %{conn: conn, project: project, user: user} do
+    conn = login(conn)
+    Repo.insert!(%LinkUserProject{user_id: user.id, project_id: project.id})
+
+    batch =
+      Repo.insert!(%Batch{
+        project_id: project.id,
+        commit: "BC",
+        state: :running
+      })
+
+    bundle = Repo.insert!(%PatchBundle{project_id: project.id})
+
+    base =
+      Repo.insert!(%Patch{
+        project_id: project.id,
+        pr_xref: 43,
+        title: "base patch",
+        bundle_id: bundle.id
+      })
+
+    stacked =
+      Repo.insert!(%Patch{
+        project_id: project.id,
+        pr_xref: 44,
+        title: "stacked patch",
+        bundle_id: bundle.id,
+        stacked_on_id: base.id
+      })
+
+    for patch <- [base, stacked] do
+      Repo.insert!(%LinkPatchBatch{patch_id: patch.id, batch_id: batch.id})
+    end
+
+    conn = get(conn, project_path(conn, :show, project))
+    html = html_response(conn, 200)
+
+    assert html =~ "Running"
+    assert html =~ "bundle-chip"
+    assert html =~ "⛓ #{bundle.id}"
+    assert html =~ "row--bundled"
+    assert html =~ "Stacked on #43"
+    # base first inside the batch, too
+    assert html =~ ~r/base patch.*stacked patch/s
   end
 
   test "show trying and waiting attempts", %{conn: conn, project: project, user: user} do


### PR DESCRIPTION
Bundled pull requests (`bors link` / `bors stack`) now show up on the repository dashboard and get their own detail page.

On the dashboard, bundled-but-unqueued PRs move out of "Awaiting review" / "Delegated" into one group per bundle, labeled Stacked or Linked. The group header says what the bundle is waiting on ("Waiting for approval of #123", "Blocked: #124 is a draft"), and an Approval column replaces "Delegated to", showing a held r+ ("✓ held (login)") or "waiting — delegated to x". A stacked bundle lists its base first with each stacked PR on the line after its base, marked with ↰ pointing up at the base the way a commit points at its parent; linked bundles keep the page's usual descending PR order.

Inside a running batch, bundle members are grouped together with a stripe and a ⛓ chip linking to the new bundle page at /bundles/:id. That page mirrors the batch details page: date, state, members in stack order, and the batches the bundle entered.

Display logic lives in the new BorsNG.BundleDisplay module, pure functions over already-loaded patches. The dashboard adds a single IN-query over the patches.bundle_id index when bundles exist, and no per-bundle queries; the bundle page is primary-key and indexed lookups only. New tests cover the ordering and state logic, the dashboard rendering, and the bundle page.

Along the way we also fix some inconsistencies in the HTTP responses for missing IDs across the frontend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)