### PR TITLE
fix: prevent unqueueable bundles from being created

### DIFF
--- a/lib/web/controllers/webhook_controller.ex
+++ b/lib/web/controllers/webhook_controller.ex
@@ -64,6 +64,7 @@ defmodule BorsNG.WebhookController do
 
   alias BorsNG.Worker.Attemptor
   alias BorsNG.Worker.Batcher
+  alias BorsNG.Worker.Batcher.Bundles
   alias BorsNG.Worker.BranchDeleter
   alias BorsNG.Worker.DelegationInvalidator
   alias BorsNG.Worker.Labeler
@@ -472,7 +473,7 @@ defmodule BorsNG.WebhookController do
     end)
   end
 
-  def do_webhook_pr(conn, %{action: "edited", patch: patch}) do
+  def do_webhook_pr(conn, %{action: "edited", project: project, patch: patch}) do
     %{
       "pull_request" => %{
         "title" => title,
@@ -481,17 +482,41 @@ defmodule BorsNG.WebhookController do
       }
     } = conn.body_params
 
-    Repo.update!(
-      Patch.changeset(patch, %{
-        title: title,
-        body: body,
-        into_branch: base_ref
-      })
-    )
+    patch =
+      Repo.update!(
+        Patch.changeset(patch, %{
+          title: title,
+          body: body,
+          into_branch: base_ref
+        })
+      )
+
+    # A base-branch change on a bundled PR can leave the bundle's stack roots
+    # disagreeing on a target branch, which wedges it at activation
+    # (`final_target` in the batcher). The edit already landed on GitHub, so we
+    # can't refuse it — warn the bundle now instead of failing silently later.
+    # Only base changes matter; title/body edits leave the bundle shape alone.
+    if patch.bundle_id != nil and get_in(conn.body_params, ["changes", "base"]) != nil do
+      warn_if_bundle_unqueueable(project, patch)
+    end
   end
 
   def do_webhook_pr(_conn, %{action: action}) do
     Logger.info(["WebhookController: Got unknown action: ", action])
+  end
+
+  defp warn_if_bundle_unqueueable(project, patch) do
+    members = Bundles.members(patch.bundle_id)
+
+    case Bundles.final_target(members) do
+      {:error, :branch_mismatch} ->
+        conn = Project.installation_connection(project.repo_xref, Repo)
+        body = Batcher.Message.generate_message({:bundle_base_edit_mismatch, patch.pr_xref})
+        Enum.each(members, &GitHub.post_comment!(conn, &1.pr_xref, body))
+
+      {:ok, _} ->
+        :ok
+    end
   end
 
   defp draft_mode_message(

--- a/lib/worker/batcher.ex
+++ b/lib/worker/batcher.ex
@@ -763,6 +763,15 @@ defmodule BorsNG.Worker.Batcher do
       {:ok, members} ->
         target = Enum.find(members, &(&1.pr_xref == target_xref))
 
+        # The shape once this edge is recorded: `patch` stops being a root and
+        # hangs under `target`. Check target-branch agreement against that
+        # shape, so an inconsistent forest is refused here instead of wedging
+        # at activation (`final_target`).
+        staged =
+          Enum.map(members, fn m ->
+            if m.id == patch.id, do: %{m | stacked_on_id: target.id}, else: m
+          end)
+
         cond do
           Bundles.creates_stack_cycle?(target, patch) ->
             send_message(repo_conn, [patch], {:link_error, :cycle})
@@ -778,6 +787,9 @@ defmodule BorsNG.Worker.Batcher do
               end
 
             send_message(repo_conn, [patch], message)
+
+          match?({:error, _}, Bundles.final_target(staged)) ->
+            send_message(repo_conn, [patch], {:link_error, :branch_mismatch})
 
           true ->
             members = Bundles.form_stacked(members, patch, target, project.id)

--- a/lib/worker/batcher/bundles.ex
+++ b/lib/worker/batcher/bundles.ex
@@ -152,10 +152,20 @@ defmodule BorsNG.Worker.Batcher.Bundles do
       true ->
         members = expand_bundles([patch | targets])
 
-        if Enum.any?(members, &in_incomplete_batch?/1) do
-          {:error, :in_batch}
-        else
-          {:ok, members}
+        cond do
+          Enum.any?(members, &in_incomplete_batch?/1) ->
+            {:error, :in_batch}
+
+          # `link` adds no stack edge, so the expanded set's roots are its final
+          # roots: refuse now if they disagree on a target branch rather than
+          # letting the bundle wedge at activation, where `final_target` fails
+          # every time. `stack` adds an edge that changes the roots, so
+          # `do_stack` runs this check against the post-edge shape instead.
+          mode == :link and match?({:error, _}, final_target(members)) ->
+            {:error, :branch_mismatch}
+
+          true ->
+            {:ok, members}
         end
     end
   end

--- a/lib/worker/batcher/message.ex
+++ b/lib/worker/batcher/message.ex
@@ -196,6 +196,10 @@ defmodule BorsNG.Worker.Batcher.Message do
     "##{child_xref} is now stacked on ##{parent_xref}: both are in a linked bundle and merge in the same batch, or not at all. The batch applies ##{parent_xref}'s changes first ([##{child_xref}'s own changes](#{compare_url})). Each pull request still needs its own `bors r+`; `bors unlink` removes the link."
   end
 
+  def generate_message({:bundle_base_edit_mismatch, xref}) do
+    "The base branch of ##{xref} changed, so its linked bundle no longer resolves to a single target branch. Bors can't queue the bundle until its members share one base again. Restore ##{xref}'s base, or `bors unlink` to split the bundle."
+  end
+
   def generate_message({:bundle_waiting, xrefs}) do
     prs = Enum.map_join(xrefs, ", ", &"##{&1}")
 

--- a/test/batcher/batcher_bundle_test.exs
+++ b/test/batcher/batcher_bundle_test.exs
@@ -267,6 +267,25 @@ defmodule BorsNG.Worker.BatcherBundleTest do
       assert comment =~ "same base branch"
     end
 
+    # The named pair share a base branch, so the per-pair check passes, but the
+    # expanded bundle would have two roots (#2 on master, #3 on feature-a). The
+    # root-consistency check refuses it rather than letting it wedge later.
+    test "link is refused when it would leave the bundle's roots on different branches",
+         %{proj: proj} do
+      put_plain_state(%{1 => [], 2 => [], 3 => []})
+      # Bundle: #2 (root, master) with #1 stacked on it (base feature-a).
+      a = insert_patch(proj, 2, %{head_ref: "feature-a"})
+      b = insert_patch(proj, 1, %{into_branch: "feature-a", stacked_on_id: a.id})
+      insert_bundle(proj, [a, b])
+      # A standalone PR also based on feature-a.
+      s = insert_patch(proj, 3, %{into_branch: "feature-a"})
+
+      Batcher.handle_cast({:link, b.id, [3]}, proj.id)
+
+      assert Repo.get!(Patch, s.id).bundle_id == nil
+      assert Enum.any?(comments_for(1), &(&1 =~ "same base branch"))
+    end
+
     test "link is refused while a target is queued", %{proj: proj} do
       put_plain_state(%{1 => [], 2 => []})
       patch = insert_patch(proj, 1)
@@ -681,6 +700,84 @@ defmodule BorsNG.Worker.BatcherBundleTest do
       assert Enum.any?(comments_for(1), &(&1 =~ "Rebase it onto #2"))
     end
 
+    # #1 and #2 form a consistent bundle targeting feature-d. Stacking #1 onto
+    # #3 (which targets develop) is rebased and cycle-free, but it would leave
+    # the bundle with two roots on different branches (#2 on feature-d, #3 on
+    # develop). Refuse it here rather than at activation.
+    test "stack is refused when it would leave the bundle's roots on different branches",
+         %{proj: proj} do
+      put_plain_state(
+        %{1 => [], 2 => [], 3 => []},
+        %{compare_status: %{{"commit-3", "commit-1"} => :ahead}}
+      )
+
+      p1 = insert_patch(proj, 1, %{into_branch: "feature-d"})
+      p2 = insert_patch(proj, 2, %{into_branch: "feature-d"})
+      insert_bundle(proj, [p1, p2])
+      p3 = insert_patch(proj, 3, %{into_branch: "develop", head_ref: "feature-d"})
+
+      Batcher.handle_cast({:stack, p1.id, [3]}, proj.id)
+
+      assert Repo.get!(Patch, p1.id).stacked_on_id == nil
+      assert Repo.get!(Patch, p3.id).bundle_id == nil
+      assert Enum.any?(comments_for(1), &(&1 =~ "same base branch"))
+    end
+
+    # Fan-out A -> {B, C}: #1 and #2 both stacked on root #3. Re-stacking #1
+    # onto #2 (once it is rebased on it) turns the tree into a chain by moving
+    # #1's single parent pointer from #3 to #2.
+    test "re-stacking moves the edge to the new parent (tree becomes a chain)",
+         %{proj: proj} do
+      put_plain_state(
+        %{1 => [], 2 => [], 3 => []},
+        %{compare_status: %{{"commit-2", "commit-1"} => :ahead}}
+      )
+
+      a = insert_patch(proj, 3, %{head_ref: "feature-a"})
+
+      b =
+        insert_patch(proj, 2, %{
+          into_branch: "feature-a",
+          head_ref: "feature-b",
+          stacked_on_id: a.id
+        })
+
+      c = insert_patch(proj, 1, %{into_branch: "feature-a", stacked_on_id: a.id})
+      insert_bundle(proj, [a, b, c])
+
+      Batcher.handle_cast({:stack, c.id, [2]}, proj.id)
+
+      assert Repo.get!(Patch, c.id).stacked_on_id == b.id
+      assert Enum.any?(comments_for(1), &(&1 =~ "stacked on #2"))
+    end
+
+    # The re-stack of the tree-to-chain conversion is refused until the child is
+    # actually rebased on its new parent; the original edge is left in place.
+    test "re-stacking is refused when not rebased, leaving the edge unchanged",
+         %{proj: proj} do
+      put_plain_state(
+        %{1 => [], 2 => [], 3 => []},
+        %{compare_status: %{{"commit-2", "commit-1"} => :diverged}}
+      )
+
+      a = insert_patch(proj, 3, %{head_ref: "feature-a"})
+
+      b =
+        insert_patch(proj, 2, %{
+          into_branch: "feature-a",
+          head_ref: "feature-b",
+          stacked_on_id: a.id
+        })
+
+      c = insert_patch(proj, 1, %{into_branch: "feature-a", stacked_on_id: a.id})
+      insert_bundle(proj, [a, b, c])
+
+      Batcher.handle_cast({:stack, c.id, [2]}, proj.id)
+
+      assert Repo.get!(Patch, c.id).stacked_on_id == a.id
+      assert Enum.any?(comments_for(1), &(&1 =~ "Rebase it onto #2"))
+    end
+
     test "stack commented on the parent names the fix", %{proj: proj} do
       # #2 contains #1's head, not the other way around. The user commented
       # `bors stack #2` on the parent instead of on the child.
@@ -881,6 +978,39 @@ defmodule BorsNG.Worker.BatcherBundleTest do
       staging_sha = state.branches["staging"]
       %{commit_message: message} = state.commits[staging_sha]
       assert message =~ ~r/\AMerge #2 #3 #1/
+    end
+
+    # One bundle holding two stacks (a forest): #1 on root #2, #3 on root #4,
+    # both roots targeting master. stack_order is breadth-first, so both roots
+    # merge before either child. final_target agrees (both roots on master), so
+    # the forest queues and merges as one batch.
+    test "a single forest bundle merges both roots before their children", %{proj: proj} do
+      put_merge_state(
+        [{1, "N"}, {2, "O"}, {3, "P"}, {4, "Q"}],
+        %{statuses: %{"iniOQNP" => %{}}}
+      )
+
+      p1 = insert_patch(proj, 1, %{commit: "N"})
+      p2 = insert_patch(proj, 2, %{commit: "O"})
+      p3 = insert_patch(proj, 3, %{commit: "P"})
+      p4 = insert_patch(proj, 4, %{commit: "Q"})
+      {_bundle, [p1, p2, p3, p4]} = insert_bundle(proj, [p1, p2, p3, p4])
+      p1 |> Patch.changeset(%{stacked_on_id: p2.id}) |> Repo.update!()
+      p3 |> Patch.changeset(%{stacked_on_id: p4.id}) |> Repo.update!()
+
+      batch = insert_waiting_batch(proj, [p1, p2, p3, p4])
+
+      Batcher.handle_info({:poll, :once}, proj.id)
+
+      assert Repo.get!(Batch, batch.id).state == :running
+
+      state =
+        GitHub.ServerMock.get_state()
+        |> Map.get({{:installation, 91}, 14})
+
+      staging_sha = state.branches["staging"]
+      %{commit_message: message} = state.commits[staging_sha]
+      assert message =~ ~r/\AMerge #2 #4 #1 #3/
     end
 
     test "two bundles in one batch merge contiguously", %{proj: proj} do

--- a/test/batcher/bundles_test.exs
+++ b/test/batcher/bundles_test.exs
@@ -39,5 +39,53 @@ defmodule BorsNG.Worker.Batcher.BundlesTest do
       b = fake_patch(2, 2, 1)
       assert Bundles.stack_order([a, b]) == [a, b]
     end
+
+    test "fan-out: two children of one parent come after it, in PR-number order" do
+      a = fake_patch(1, 5)
+      b = fake_patch(2, 6, 1)
+      c = fake_patch(3, 7, 1)
+      assert Bundles.stack_order([c, b, a]) == [a, b, c]
+    end
+
+    test "forest: multiple roots order breadth-first (roots first, by PR number)" do
+      r1 = fake_patch(1, 2)
+      r2 = fake_patch(2, 4)
+      c1 = fake_patch(3, 1, 1)
+      c2 = fake_patch(4, 3, 2)
+      assert Bundles.stack_order([c1, r1, c2, r2]) == [r1, r2, c1, c2]
+    end
+  end
+
+  describe "final_target/1" do
+    defp target_patch(id, into, stacked_on \\ nil) do
+      %Patch{id: id, into_branch: into, stacked_on_id: stacked_on}
+    end
+
+    test "a single root gives its branch" do
+      root = target_patch(1, "master")
+      child = target_patch(2, "feature-a", 1)
+      assert {:ok, "master"} = Bundles.final_target([child, root])
+    end
+
+    test "multiple roots that agree give the shared branch" do
+      r1 = target_patch(1, "master")
+      r2 = target_patch(2, "master")
+      c1 = target_patch(3, "feature-a", 1)
+      assert {:ok, "master"} = Bundles.final_target([r1, r2, c1])
+    end
+
+    test "roots that disagree are a mismatch" do
+      r1 = target_patch(1, "master")
+      r2 = target_patch(2, "develop")
+      assert {:error, :branch_mismatch} = Bundles.final_target([r1, r2])
+    end
+
+    test "a member stacked on an out-of-set parent counts as a root" do
+      # 2's parent (99) is not in the set, so 2 is a root; its branch must
+      # agree with the in-set root, and here it does not.
+      root = target_patch(1, "master")
+      orphan = target_patch(2, "develop", 99)
+      assert {:error, :branch_mismatch} = Bundles.final_target([root, orphan])
+    end
   end
 end

--- a/test/bundle_display_test.exs
+++ b/test/bundle_display_test.exs
@@ -59,6 +59,29 @@ defmodule BorsNG.BundleDisplayTest do
       assert [11, 10] =
                members |> BundleDisplay.display_order() |> Enum.map(& &1.pr_xref)
     end
+
+    test "fan-out: a base with two children lists the base, then children descending" do
+      base = patch(1, 10)
+      child_low = patch(2, 11, stacked_on: 1)
+      child_high = patch(3, 12, stacked_on: 1)
+
+      assert [10, 12, 11] =
+               [child_low, base, child_high]
+               |> BundleDisplay.display_order()
+               |> Enum.map(& &1.pr_xref)
+    end
+
+    test "forest: each root heads its own chain (depth-first), roots descending" do
+      r_low = patch(1, 10)
+      r_high = patch(2, 20)
+      c_low = patch(3, 11, stacked_on: 1)
+      c_high = patch(4, 21, stacked_on: 2)
+
+      assert [20, 21, 10, 11] =
+               [c_low, r_low, c_high, r_high]
+               |> BundleDisplay.display_order()
+               |> Enum.map(& &1.pr_xref)
+    end
   end
 
   describe "state/1" do

--- a/test/controllers/webhook_controller_test.exs
+++ b/test/controllers/webhook_controller_test.exs
@@ -4,6 +4,7 @@ defmodule BorsNG.WebhookControllerTest do
   alias BorsNG.Database.Installation
   alias BorsNG.Database.Attempt
   alias BorsNG.Database.Patch
+  alias BorsNG.Database.PatchBundle
   alias BorsNG.Database.Project
   alias BorsNG.Database.Repo
   alias BorsNG.Database.UserPatchDelegation
@@ -125,6 +126,126 @@ defmodule BorsNG.WebhookControllerTest do
     patch2 = Repo.get!(Patch, patch.id)
     assert patch2.into_branch == "release"
     assert patch2.retargeted_from == nil
+  end
+
+  # A base change that leaves a bundle's stack roots on different target
+  # branches makes the bundle unqueueable. The edit already landed on GitHub
+  # and can't be refused, so warn every member.
+  test "a base edit that splits a bundle's target warns every member",
+       %{conn: conn, project: project} do
+    GitHub.ServerMock.put_state(%{
+      {{:installation, 31}, 13} => %{
+        branches: %{},
+        comments: %{1 => [], 2 => []},
+        statuses: %{},
+        files: %{}
+      }
+    })
+
+    bundle = Repo.insert!(PatchBundle.new(project.id))
+
+    Repo.insert!(%Patch{
+      pr_xref: 1,
+      project_id: project.id,
+      into_branch: "master",
+      bundle_id: bundle.id
+    })
+
+    Repo.insert!(%Patch{
+      pr_xref: 2,
+      project_id: project.id,
+      into_branch: "master",
+      bundle_id: bundle.id
+    })
+
+    body_params = %{
+      "repository" => %{"id" => 13},
+      "action" => "edited",
+      "changes" => %{"base" => %{"ref" => %{"from" => "master"}}},
+      "pull_request" => %{
+        "number" => 1,
+        "title" => "T",
+        "body" => "B",
+        "state" => "open",
+        "base" => %{"ref" => "develop", "repo" => %{"id" => 456}},
+        "head" => %{"sha" => "S", "ref" => "BAR_BRANCH", "repo" => %{"id" => 345}},
+        "merged_at" => nil,
+        "mergeable" => true,
+        "user" => %{"id" => 23, "login" => "ghost", "avatar_url" => "U"}
+      }
+    }
+
+    conn
+    |> put_req_header("x-github-event", "pull_request")
+    |> post(webhook_path(conn, :webhook, "github"), body_params)
+
+    comments_for = fn pr ->
+      GitHub.ServerMock.get_state() |> get_in([{{:installation, 31}, 13}, :comments, pr]) || []
+    end
+
+    assert Enum.any?(comments_for.(1), &(&1 =~ "no longer resolves to a single target branch"))
+    assert Enum.any?(comments_for.(2), &(&1 =~ "no longer resolves to a single target branch"))
+  end
+
+  # Editing a stacked child's base does not move the bundle's root, so its
+  # single target branch is intact: no warning.
+  test "a base edit that keeps one target does not warn",
+       %{conn: conn, project: project} do
+    GitHub.ServerMock.put_state(%{
+      {{:installation, 31}, 13} => %{
+        branches: %{},
+        comments: %{1 => [], 2 => []},
+        statuses: %{},
+        files: %{}
+      }
+    })
+
+    bundle = Repo.insert!(PatchBundle.new(project.id))
+
+    parent =
+      Repo.insert!(%Patch{
+        pr_xref: 2,
+        project_id: project.id,
+        into_branch: "master",
+        head_ref: "feature-a",
+        bundle_id: bundle.id
+      })
+
+    Repo.insert!(%Patch{
+      pr_xref: 1,
+      project_id: project.id,
+      into_branch: "feature-a",
+      stacked_on_id: parent.id,
+      bundle_id: bundle.id
+    })
+
+    body_params = %{
+      "repository" => %{"id" => 13},
+      "action" => "edited",
+      "changes" => %{"base" => %{"ref" => %{"from" => "feature-a"}}},
+      "pull_request" => %{
+        "number" => 1,
+        "title" => "T",
+        "body" => "B",
+        "state" => "open",
+        "base" => %{"ref" => "feature-x", "repo" => %{"id" => 456}},
+        "head" => %{"sha" => "S", "ref" => "feature-b", "repo" => %{"id" => 345}},
+        "merged_at" => nil,
+        "mergeable" => true,
+        "user" => %{"id" => 23, "login" => "ghost", "avatar_url" => "U"}
+      }
+    }
+
+    conn
+    |> put_req_header("x-github-event", "pull_request")
+    |> post(webhook_path(conn, :webhook, "github"), body_params)
+
+    comments_for = fn pr ->
+      GitHub.ServerMock.get_state() |> get_in([{{:installation, 31}, 13}, :comments, pr]) || []
+    end
+
+    assert comments_for.(1) == []
+    assert comments_for.(2) == []
   end
 
   test "sync PR on reopen", %{conn: conn, project: project} do


### PR DESCRIPTION
A bundle is *unqueueable* when its stack roots disagree on a target branch: `final_target/1` fails at activation, and the bundle re-posts a branch-mismatch on every attempt to merge and this can only be fixed with `bors unlink`.

The link-time check only compared the two **named** PRs' base branches, not the full expanded membership. Since a stacked child's base is legitimately a feature branch, two paths could smuggle a mismatched root into a bundle:

1. **Link-time** — `bors link`ing a PR against a stacked child on the child's feature branch passes the pair check but leaves the bundle with roots on different target branches.
2. **Base edit** — editing a bundled PR's base on GitHub is absorbed with no bundle validation at all, silently making the bundle unqueueable.

Neither was dangerous (the queue-time `final_target` gate still blocks a bad merge), but both produced a confusing "silently stuck" bundle discovered only at activation.

Fixes:

- **`validate_link` (link mode)** now runs `final_target/1` over the fully expanded member set and refuses a root mismatch up front, reusing the existing `:branch_mismatch` error.
- **`do_stack`** checks `final_target/1` against the *post-edge* shape (the child staged onto its new parent), so an inconsistent forest is refused at command time without rejecting ordinary stacks.
- **`edited` webhook** can't refuse a base change already on GitHub, so when a base edit leaves a bundled PR's roots disagreeing it **warns every member** (new `:bundle_base_edit_mismatch` message) instead of failing silently later.

Tests:

- The two gates and both base-edit warn cases (breaks / doesn't break).
- The structural scenarios the gates rest on: fan-out trees (`A → {B, C}`), multi-root forests, re-stacking (tree→chain, and refused-until-rebased), and direct `final_target/1` unit coverage.

These also pin down that **merge order is breadth-first** (`stack_order`) while **display order is depth-first** (`display_order`) — they differ for forests/fan-outs, now locked in by tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)