### PR TITLE
feat(web): show stacked-PR bundles as an indented tree

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -444,6 +444,24 @@ tr.row--bundled > td:first-child {
 .approval--waiting {
   color: #666;
 }
+/* A stack member's readiness dot, shown before its PR number */
+.stack-dot {
+  padding-right: 6px;
+}
+.stack-dot--held {
+  color: #3c763d;
+}
+.stack-dot--waiting {
+  color: #666;
+}
+.stack-dot--blocked {
+  color: #a94442;
+}
+/* Bundle members on the bundle detail page: indented, no list bullets */
+.stack-list {
+  list-style: none;
+  padding-left: 0;
+}
 /* Allow preformatted text to wrap (crash reports) */
 pre {
   white-space: pre-wrap;
@@ -516,5 +534,11 @@ time[title] {
   }
   .approval--held {
       color:#7bbf82;
+  }
+  .stack-dot--held {
+      color:#7bbf82;
+  }
+  .stack-dot--waiting {
+      color:#999;
   }
 }

--- a/lib/web/bundle_display.ex
+++ b/lib/web/bundle_display.ex
@@ -23,6 +23,15 @@ defmodule BorsNG.BundleDisplay do
   bundle) fall back to descending PR order at the end.
   """
   def display_order(members) do
+    members |> display_rows() |> Enum.map(&elem(&1, 0))
+  end
+
+  @doc """
+  Members in display order, each paired with its stack depth: 0 for a root
+  (or a member whose base has left the bundle), one deeper for each stacked
+  descendant. Ordering matches `display_order/1`.
+  """
+  def display_rows(members) do
     ids = MapSet.new(members, & &1.id)
 
     {roots, rest} =
@@ -36,26 +45,46 @@ defmodule BorsNG.BundleDisplay do
     ordered =
       roots
       |> Enum.sort_by(& &1.pr_xref, :desc)
-      |> Enum.flat_map(&chain(&1, by_base))
+      |> Enum.flat_map(&chain(&1, by_base, 0))
 
-    ordered_ids = MapSet.new(ordered, & &1.id)
+    ordered_ids = MapSet.new(ordered, fn {patch, _depth} -> patch.id end)
 
     leftover =
       members
       |> Enum.reject(&MapSet.member?(ordered_ids, &1.id))
       |> Enum.sort_by(& &1.pr_xref, :desc)
+      |> Enum.map(&{&1, 0})
 
     ordered ++ leftover
   end
 
-  defp chain(patch, by_base) do
+  defp chain(patch, by_base, depth) do
     stacked =
       by_base
       |> Map.get(patch.id, [])
       |> Enum.sort_by(& &1.pr_xref, :desc)
-      |> Enum.flat_map(&chain(&1, by_base))
+      |> Enum.flat_map(&chain(&1, by_base, depth + 1))
 
-    [patch | stacked]
+    [{patch, depth} | stacked]
+  end
+
+  @doc """
+  Maps each patch id to its stack depth, grouping by bundle: 0 for an unbundled
+  patch or a stack root, one deeper for each stacked descendant. For patches
+  ordered by something other than `display_rows/1` — such as a batch's merge
+  order — that still want the indent.
+  """
+  def depths(patches) do
+    patches
+    |> Enum.group_by(& &1.bundle_id)
+    |> Enum.flat_map(fn
+      {nil, singles} ->
+        Enum.map(singles, &{&1.id, 0})
+
+      {_bundle_id, members} ->
+        members |> display_rows() |> Enum.map(fn {patch, depth} -> {patch.id, depth} end)
+    end)
+    |> Map.new()
   end
 
   @doc """
@@ -85,21 +114,39 @@ defmodule BorsNG.BundleDisplay do
   def blocker_reason(%Patch{}), do: "a draft"
 
   @doc """
+  A member's readiness, for the status dot shown beside it: `:blocked` (closed
+  or a draft), `:held` (an approval is held), or `:waiting`.
+  """
+  def member_status(%Patch{open: false}), do: :blocked
+  def member_status(%Patch{is_draft: true}), do: :blocked
+  def member_status(%Patch{bundle_reviewer: reviewer}) when not is_nil(reviewer), do: :held
+  def member_status(%Patch{}), do: :waiting
+
+  @doc """
   A batch's patches in display order: descending PR order, except bundle
   members stay together (sorted by their highest member) with stacks base
   first.
   """
   def batch_display_order(patches) do
+    patches |> batch_display_rows() |> Enum.map(&elem(&1, 0))
+  end
+
+  @doc """
+  A batch's patches in display order, each paired with its stack depth (0 for a
+  single patch or a bundle root). Same grouping as `batch_display_order/1`;
+  within a bundle, members carry the depth from `display_rows/1`.
+  """
+  def batch_display_rows(patches) do
     {bundled, singles} = Enum.split_with(patches, & &1.bundle_id)
 
     bundle_groups =
       bundled
       |> Enum.group_by(& &1.bundle_id)
       |> Enum.map(fn {_id, members} ->
-        {members |> Enum.map(& &1.pr_xref) |> Enum.max(), display_order(members)}
+        {members |> Enum.map(& &1.pr_xref) |> Enum.max(), display_rows(members)}
       end)
 
-    single_groups = Enum.map(singles, &{&1.pr_xref, [&1]})
+    single_groups = Enum.map(singles, &{&1.pr_xref, [{&1, 0}]})
 
     (bundle_groups ++ single_groups)
     |> Enum.sort_by(&elem(&1, 0), :desc)

--- a/lib/web/controllers/batch_controller.ex
+++ b/lib/web/controllers/batch_controller.ex
@@ -7,22 +7,33 @@ defmodule BorsNG.BatchController do
 
   use BorsNG.Web, :controller
 
+  alias BorsNG.BundleDisplay
   alias BorsNG.Database.Batch
-  alias BorsNG.Database.Repo
-  alias BorsNG.Database.Patch
+  alias BorsNG.Database.LinkPatchBatch
   alias BorsNG.Database.Project
+  alias BorsNG.Database.Repo
   alias BorsNG.Database.Status
+  alias BorsNG.Worker.Batcher.Bundles
 
   def show(conn, %{"id" => id}) do
     batch = Repo.get!(Batch, id)
     project = Repo.get(Project, batch.project_id)
 
-    patches = Repo.all(Patch.all_for_batch(batch.id))
+    # Merge order, not PR order: bundles stay contiguous and a stacked patch
+    # follows the patch it stacks on, exactly as the batcher will land them.
+    patches =
+      batch.id
+      |> LinkPatchBatch.from_batch()
+      |> Repo.all()
+      |> Bundles.sort_links_for_merge()
+      |> Enum.map(& &1.patch)
+
     statuses = Repo.all(Status.all_for_batch(batch.id))
 
     render(conn, "show.html",
       batch: batch,
       patches: patches,
+      depths: BundleDisplay.depths(patches),
       project: project,
       statuses: statuses
     )

--- a/lib/web/controllers/bundle_controller.ex
+++ b/lib/web/controllers/bundle_controller.ex
@@ -50,7 +50,7 @@ defmodule BorsNG.BundleController do
     render(conn, "show.html",
       bundle: bundle,
       project: project,
-      members: BundleDisplay.display_order(members),
+      members: BundleDisplay.display_rows(members),
       state: BundleDisplay.state(members),
       stacked: BundleDisplay.stacked?(members),
       batches: batches,

--- a/lib/web/controllers/project_controller.ex
+++ b/lib/web/controllers/project_controller.ex
@@ -105,7 +105,7 @@ defmodule BorsNG.ProjectController do
         batch.id
         |> Patch.all_for_batch()
         |> Repo.all()
-        |> BundleDisplay.batch_display_order(),
+        |> BundleDisplay.batch_display_rows(),
       priority: batch.priority,
       state: batch.state
     }
@@ -123,7 +123,7 @@ defmodule BorsNG.ProjectController do
     |> Enum.map(fn {id, members} ->
       %{
         id: id,
-        members: BundleDisplay.display_order(members),
+        members: BundleDisplay.display_rows(members),
         state: BundleDisplay.state(members),
         stacked: BundleDisplay.stacked?(members)
       }

--- a/lib/web/templates/batch/show.html.eex
+++ b/lib/web/templates/batch/show.html.eex
@@ -33,16 +33,25 @@
   </li>
   <% end %>
 </ul>
-<p>
-  Pull Requests:
-  <ul>
-    <%= for patch <- @patches do %>
-    <li>
-      <a href="<%= Confex.fetch_env!(:bors, :html_github_root) %>/<%= @project.name %>/pull/<%= patch.pr_xref %>">#<%= patch.pr_xref %></a>
-    </li>
+<p>Pull requests (merge order):</p>
+<table class="table">
+  <thead>
+    <tr role="row"><th>Order</th><th>#</th><th>Title</th></tr>
+  </thead>
+  <tbody>
+    <%= for {patch, i} <- Enum.with_index(@patches) do %>
+    <tr role="row" id="prrow-<%= patch.pr_xref %>"<%= if patch.bundle_id do %> class=row--bundled<% end %>>
+      <td><%= i + 1 %></td>
+      <td class=expand-row style="padding-left: <%= 10 + Map.get(@depths, patch.id, 0) * 20 %>px">
+        <%= patch.pr_xref %><%= if patch.bundle_id do %> <a class=bundle-chip href="../bundles/<%= patch.bundle_id %>" title="Bundle <%= patch.bundle_id %> — merges atomically">⛓ <%= patch.bundle_id %></a><% end %>
+      </td>
+      <td class="fill-link">
+        <a href="<%= Confex.fetch_env!(:bors, :html_github_root) %>/<%= @project.name %>/pull/<%= patch.pr_xref %>"><%= patch.title %></a>
+      </td>
+    </tr>
     <% end %>
-  </ul>
-</p>
+  </tbody>
+</table>
 
 <% else %>
 There is no such batch

--- a/lib/web/templates/bundle/show.html.eex
+++ b/lib/web/templates/bundle/show.html.eex
@@ -22,12 +22,12 @@
 <p>Date: <%= htmlify_naive_datetime(@bundle.inserted_at) %></p>
 <p>State: <%= render(BorsNG.ProjectView, "_bundle_state.html", state: @state, project: @project) %></p>
 <p>Pull requests<%= if @stacked do %> (stack order)<% end %>:</p>
-<% xrefs = Map.new(@members, &{&1.id, &1.pr_xref}) %>
-<ul>
-  <%= for patch <- @members do %>
-  <li>
-    <%= if patch.stacked_on_id && xrefs[patch.stacked_on_id] do %><span class=stack-mark title="Stacked on #<%= xrefs[patch.stacked_on_id] %>">↰</span><% end %>
-    <a href="<%= Confex.fetch_env!(:bors, :html_github_root) %>/<%= @project.name %>/pull/<%= patch.pr_xref %>">#<%= patch.pr_xref %></a>
+<% xrefs = Map.new(@members, fn {patch, _depth} -> {patch.id, patch.pr_xref} end) %>
+<ul class=stack-list>
+  <%= for {patch, depth} <- @members do %>
+  <li style="padding-left: <%= depth * 20 %>px">
+    <span class="stack-dot stack-dot--<%= BorsNG.BundleDisplay.member_status(patch) %>" aria-hidden="true">●</span>
+    <a href="<%= Confex.fetch_env!(:bors, :html_github_root) %>/<%= @project.name %>/pull/<%= patch.pr_xref %>"<%= if patch.stacked_on_id && xrefs[patch.stacked_on_id] do %> title="Stacked on #<%= xrefs[patch.stacked_on_id] %>"<% end %>>#<%= patch.pr_xref %></a>
     —
     <%= cond do %>
     <% not patch.open -> %>

--- a/lib/web/templates/project/show.html.eex
+++ b/lib/web/templates/project/show.html.eex
@@ -35,11 +35,11 @@
     <tr role=row><th>#</th><th aria-label=Mergeable title=Mergeable>M<span class=hide-on-narrow>ergeable</span></th><th>Title</th><th aria-label="Delegated to" title="Delegated to">D<span class=hide-on-narrow>elegated to</span></th><th class=priority-column>Priority</th><th class=hide-on-super-narrow>Commit</th></tr>
   </thead>
   <tbody>
-  <% xrefs = Map.new(batch.patches, &{&1.id, &1.pr_xref}) %>
-  <%= for patch <- batch.patches do %>
+  <% xrefs = Map.new(batch.patches, fn {patch, _depth} -> {patch.id, patch.pr_xref} end) %>
+  <%= for {patch, depth} <- batch.patches do %>
     <tr role="row" id="prrow-<%= patch.pr_xref %>"<%= if patch.bundle_id do %> class=row--bundled<% end %>>
-      <td class=expand-row>
-        <%= patch.pr_xref %><%= if patch.bundle_id do %> <a class=bundle-chip href="../bundles/<%= patch.bundle_id %>" title="Bundle <%= patch.bundle_id %> — merges atomically">⛓ <%= patch.bundle_id %></a><% end %>
+      <td class=expand-row style="padding-left: <%= 10 + depth * 20 %>px">
+        <%= if patch.bundle_id do %><span class="stack-dot stack-dot--<%= BorsNG.BundleDisplay.member_status(patch) %>" aria-hidden="true">●</span><% end %><%= patch.pr_xref %><%= if patch.bundle_id do %> <a class=bundle-chip href="../bundles/<%= patch.bundle_id %>" title="Bundle <%= patch.bundle_id %> — merges atomically">⛓ <%= patch.bundle_id %></a><% end %>
       </td>
       <td class=span--<%= if patch.is_mergeable do %>ok<% else %>error<% end %> aria-label="<%= if patch.is_mergeable do %><%= if patch.is_draft do %>Draft<% else %>Yes<% end %><% else %>No<% end %>" title="<%= if patch.is_mergeable do %><%= if patch.is_draft do %>Draft<% else %>Yes<% end %><% else %>No<% end %>">
         <%= if patch.is_mergeable do %>
@@ -53,8 +53,8 @@
         <% end %>
       </td>
       <td class="fill-link">
-        <a href="<%= Confex.fetch_env!(:bors, :html_github_root) %>/<%= @project.name %>/pull/<%= patch.pr_xref %>">
-          <%= if patch.stacked_on_id && xrefs[patch.stacked_on_id] do %><span class=stack-mark title="Stacked on #<%= xrefs[patch.stacked_on_id] %>">↰</span><% end %><%= patch.title %>
+        <a href="<%= Confex.fetch_env!(:bors, :html_github_root) %>/<%= @project.name %>/pull/<%= patch.pr_xref %>"<%= if patch.stacked_on_id && xrefs[patch.stacked_on_id] do %> title="Stacked on #<%= xrefs[patch.stacked_on_id] %>"<% end %>>
+          <%= patch.title %>
         </a>
       </td>
       <td class=delegated-cell>
@@ -72,7 +72,7 @@
   </tbody>
 <% end %>
 <%= for bundle <- @bundles do %>
-  <% xrefs = Map.new(bundle.members, &{&1.id, &1.pr_xref}) %>
+  <% xrefs = Map.new(bundle.members, fn {patch, _depth} -> {patch.id, patch.pr_xref} end) %>
   <thead>
     <tr role=heading><td aria-role=presentation colspan=6>
       <a href="../bundles/<%= bundle.id %>">Bundle <%= bundle.id %></a>
@@ -85,10 +85,10 @@
     <tr role=row><th>#</th><th aria-label=Mergeable title=Mergeable>M<span class=hide-on-narrow>ergeable</span></th><th>Title</th><th aria-label=Approval title=Approval>A<span class=hide-on-narrow>pproval</span></th><th class=priority-column>Priority</th><th class=hide-on-super-narrow>Commit</th></tr>
   </thead>
   <tbody>
-  <%= for patch <- bundle.members do %>
+  <%= for {patch, depth} <- bundle.members do %>
     <tr role="row" id="prrow-<%= patch.pr_xref %>">
-      <td class=expand-row>
-        <%= patch.pr_xref %>
+      <td class=expand-row style="padding-left: <%= 10 + depth * 20 %>px">
+        <span class="stack-dot stack-dot--<%= BorsNG.BundleDisplay.member_status(patch) %>" aria-hidden="true">●</span><%= patch.pr_xref %>
       </td>
       <%= if patch.open do %>
       <td class=span--<%= if patch.is_mergeable do %>ok<% else %>error<% end %> aria-label="<%= if patch.is_mergeable do %><%= if patch.is_draft do %>Draft<% else %>Yes<% end %><% else %>No<% end %>" title="<%= if patch.is_mergeable do %><%= if patch.is_draft do %>Draft<% else %>Yes<% end %><% else %>No<% end %>">
@@ -106,8 +106,8 @@
       <td class=span--error aria-label=Closed title=Closed>✗<span class=hide-on-narrow> Closed</span></td>
       <% end %>
       <td class="fill-link">
-        <a href="<%= Confex.fetch_env!(:bors, :html_github_root) %>/<%= @project.name %>/pull/<%= patch.pr_xref %>">
-          <%= if patch.stacked_on_id && xrefs[patch.stacked_on_id] do %><span class=stack-mark title="Stacked on #<%= xrefs[patch.stacked_on_id] %>">↰</span><% end %><%= patch.title %>
+        <a href="<%= Confex.fetch_env!(:bors, :html_github_root) %>/<%= @project.name %>/pull/<%= patch.pr_xref %>"<%= if patch.stacked_on_id && xrefs[patch.stacked_on_id] do %> title="Stacked on #<%= xrefs[patch.stacked_on_id] %>"<% end %>>
+          <%= patch.title %>
         </a>
       </td>
       <%= if patch.bundle_reviewer do %>

--- a/test/bundle_display_test.exs
+++ b/test/bundle_display_test.exs
@@ -61,6 +61,73 @@ defmodule BorsNG.BundleDisplayTest do
     end
   end
 
+  describe "display_rows/1" do
+    test "roots are depth 0, each stacked PR one deeper" do
+      base = patch(1, 10)
+      mid = patch(2, 11, stacked_on: 1)
+      top = patch(3, 12, stacked_on: 2)
+
+      assert [{10, 0}, {11, 1}, {12, 2}] =
+               [top, base, mid]
+               |> BundleDisplay.display_rows()
+               |> Enum.map(fn {p, depth} -> {p.pr_xref, depth} end)
+    end
+
+    test "a plain linked bundle is all depth 0" do
+      members = [patch(1, 10), patch(2, 12), patch(3, 11)]
+
+      assert [{12, 0}, {11, 0}, {10, 0}] =
+               members
+               |> BundleDisplay.display_rows()
+               |> Enum.map(fn {p, depth} -> {p.pr_xref, depth} end)
+    end
+
+    test "siblings on a branching base share a depth, base leads" do
+      base = patch(1, 10)
+      left = patch(2, 11, stacked_on: 1)
+      right = patch(3, 12, stacked_on: 1)
+
+      rows =
+        [base, left, right]
+        |> BundleDisplay.display_rows()
+        |> Enum.map(fn {p, depth} -> {p.pr_xref, depth} end)
+
+      assert hd(rows) == {10, 0}
+      assert {11, 1} in rows
+      assert {12, 1} in rows
+    end
+  end
+
+  describe "depths/1" do
+    test "depth per patch id; singles and roots at 0" do
+      base = patch(1, 10, bundle_id: 7)
+      top = patch(2, 11, bundle_id: 7, stacked_on: 1)
+      lone = patch(3, 12, bundle_id: nil)
+
+      # keyed by patch id (base id 1, top id 2, lone id 3), as the templates look it up
+      depths = BundleDisplay.depths([lone, top, base])
+
+      assert depths[1] == 0
+      assert depths[2] == 1
+      assert depths[3] == 0
+    end
+  end
+
+  describe "member_status/1" do
+    test "held when an approval is held" do
+      assert BundleDisplay.member_status(patch(1, 10, reviewer: "r")) == :held
+    end
+
+    test "waiting with no approval" do
+      assert BundleDisplay.member_status(patch(1, 10)) == :waiting
+    end
+
+    test "blocked when closed or a draft, even holding an approval" do
+      assert BundleDisplay.member_status(patch(1, 10, draft: true)) == :blocked
+      assert BundleDisplay.member_status(patch(1, 10, reviewer: "r", open: false)) == :blocked
+    end
+  end
+
   describe "state/1" do
     test "waiting on the members without a held approval" do
       held = patch(1, 10, reviewer: "reviewer")
@@ -103,6 +170,17 @@ defmodule BorsNG.BundleDisplayTest do
                [lone_low, top, lone_high, base]
                |> BundleDisplay.batch_display_order()
                |> Enum.map(& &1.pr_xref)
+    end
+
+    test "carries stack depth; singles are depth 0" do
+      base = patch(1, 10, bundle_id: 7)
+      top = patch(2, 11, bundle_id: 7, stacked_on: 1)
+      lone = patch(3, 12, bundle_id: nil)
+
+      assert [{12, 0}, {10, 0}, {11, 1}] =
+               [lone, top, base]
+               |> BundleDisplay.batch_display_rows()
+               |> Enum.map(fn {p, depth} -> {p.pr_xref, depth} end)
     end
   end
 end

--- a/test/controllers/batch_controller_test.exs
+++ b/test/controllers/batch_controller_test.exs
@@ -7,6 +7,7 @@ defmodule BorsNG.BatchControllerTest do
   alias BorsNG.Database.LinkMemberProject
   alias BorsNG.Database.LinkUserProject
   alias BorsNG.Database.Patch
+  alias BorsNG.Database.PatchBundle
   alias BorsNG.Database.Project
   alias BorsNG.Database.Repo
   alias BorsNG.Database.Status
@@ -100,7 +101,7 @@ defmodule BorsNG.BatchControllerTest do
     assert html_response(conn, 200) =~ "Batch Details"
     assert html_response(conn, 200) =~ "Priority: 33"
     assert html_response(conn, 200) =~ "State: Invalid"
-    assert html_response(conn, 200) =~ "#43"
+    assert html_response(conn, 200) =~ "/pull/43"
     assert html_response(conn, 200) =~ "<span>some-identifier (Running)</span>"
 
     assert html_response(conn, 200) =~
@@ -124,7 +125,7 @@ defmodule BorsNG.BatchControllerTest do
     assert html_response(conn, 200) =~ "Batch Details"
     assert html_response(conn, 200) =~ "Priority: 33"
     assert html_response(conn, 200) =~ "State: Invalid"
-    assert html_response(conn, 200) =~ "#43"
+    assert html_response(conn, 200) =~ "/pull/43"
     assert html_response(conn, 200) =~ "<span>some-identifier (Running)</span>"
 
     assert html_response(conn, 200) =~
@@ -148,7 +149,7 @@ defmodule BorsNG.BatchControllerTest do
     assert html_response(conn, 200) =~ "Batch Details"
     assert html_response(conn, 200) =~ "Priority: 33"
     assert html_response(conn, 200) =~ "State: Invalid"
-    assert html_response(conn, 200) =~ "#43"
+    assert html_response(conn, 200) =~ "/pull/43"
     assert html_response(conn, 200) =~ "<span>some-identifier (Running)</span>"
 
     assert html_response(conn, 200) =~
@@ -162,6 +163,38 @@ defmodule BorsNG.BatchControllerTest do
     conn = get(conn, "/batches/#{batch.id}")
 
     assert html_response(conn, 200) =~ "Batch Details"
+  end
+
+  test "lists pull requests in merge order", %{conn: conn, project: project, batch: batch} do
+    bundle = Repo.insert!(%PatchBundle{project_id: project.id})
+
+    base =
+      Repo.insert!(%Patch{
+        project_id: project.id,
+        pr_xref: 44,
+        title: "base patch",
+        bundle_id: bundle.id
+      })
+
+    top =
+      Repo.insert!(%Patch{
+        project_id: project.id,
+        pr_xref: 45,
+        title: "stacked patch",
+        bundle_id: bundle.id,
+        stacked_on_id: base.id
+      })
+
+    Repo.insert!(%LinkPatchBatch{patch_id: base.id, batch_id: batch.id})
+    Repo.insert!(%LinkPatchBatch{patch_id: top.id, batch_id: batch.id})
+
+    conn = login(conn)
+    conn = get(conn, "/batches/#{batch.id}")
+    html = html_response(conn, 200)
+
+    assert html =~ "merge order"
+    # the base merges before the patch stacked on it
+    assert html =~ ~r/base patch.*stacked patch/s
   end
 
   test "returns 404 when there is no such batch", %{conn: conn} do


### PR DESCRIPTION
Bundles that stack multiple PRs used to display as a flat list with a single ↰ marker, which hid the forest structure — depth, branching, and which stack a PR belonged to. This makes that structure legible.

Each bundle member now renders indented by its stack depth, with a small readiness dot (green held / grey waiting / red blocked), on the bundle detail page and on the dashboard's bundle and batch groups. The ↰ marker is gone; the ⛓ bundle chip and the row--bundled stripe stay.

The batch detail page's plain list of PRs becomes a table with a merge-order column, ordered by the same `Bundles.sort_links_for_merge/1` the batcher uses when it lands a batch, so the page reflects the order the patches will actually merge in.

Internals: `BundleDisplay` gains `display_rows/1` (which pairs each member with its stack depth), `member_status/1`, and `depths/1`; `display_order/1` and `batch_display_order/1` now derive from those with unchanged ordering. Styling reuses the existing bundle palette in both light and dark themes.

Tests added for the new helpers and the batch page's merge ordering; the existing bundle, batch, and project controller tests still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)