### PR TITLE
feat: link bundle PR comments to the bundle page

### DIFF
--- a/lib/web/command.ex
+++ b/lib/web/command.ex
@@ -857,12 +857,15 @@ defmodule BorsNG.Command do
     # `try` knows nothing about bundles: it builds this patch's branch alone.
     # Say so, or a green result overstates what the batch will do.
     if c.patch.bundle_id != nil do
+      body =
+        Batcher.Message.generate_message(:try_ignores_bundle) <>
+          Batcher.Message.bundle_link_footer(
+            bundle_url(BorsNG.Endpoint, :show, c.patch.bundle_id)
+          )
+
       c.project.repo_xref
       |> Project.installation_connection(Repo)
-      |> GitHub.post_comment!(
-        c.pr_xref,
-        Batcher.Message.generate_message(:try_ignores_bundle)
-      )
+      |> GitHub.post_comment!(c.pr_xref, body)
     end
 
     attemptor = Attemptor.Registry.get(c.project.id)

--- a/lib/web/command.ex
+++ b/lib/web/command.ex
@@ -858,10 +858,10 @@ defmodule BorsNG.Command do
     # Say so, or a green result overstates what the batch will do.
     if c.patch.bundle_id != nil do
       body =
-        Batcher.Message.generate_message(:try_ignores_bundle) <>
-          Batcher.Message.bundle_link_footer(
-            bundle_url(BorsNG.Endpoint, :show, c.patch.bundle_id)
-          )
+        Batcher.Message.generate_message(
+          :try_ignores_bundle,
+          bundle_url(BorsNG.Endpoint, :show, c.patch.bundle_id)
+        )
 
       c.project.repo_xref
       |> Project.installation_connection(Repo)

--- a/lib/worker/batcher.ex
+++ b/lib/worker/batcher.ex
@@ -2115,7 +2115,7 @@ defmodule BorsNG.Worker.Batcher do
   end
 
   defp send_message(repo_conn, patches, message) do
-    body = Batcher.Message.generate_message(message)
+    body = append_bundle_link(Batcher.Message.generate_message(message), message, patches)
 
     case body do
       nil ->
@@ -2133,6 +2133,20 @@ defmodule BorsNG.Worker.Batcher do
               )
           end
         end)
+    end
+  end
+
+  # A comment about an existing bundle gets a link to its dashboard page. All
+  # members of a bundle share a bundle_id, so the first patch's is
+  # representative of the group send_message posts to.
+  defp append_bundle_link(nil, _message, _patches), do: nil
+
+  defp append_bundle_link(body, message, patches) do
+    with true <- Batcher.Message.links_to_bundle?(message),
+         [%Patch{bundle_id: bundle_id} | _] when not is_nil(bundle_id) <- patches do
+      body <> Batcher.Message.bundle_link_footer(bundle_url(Endpoint, :show, bundle_id))
+    else
+      _ -> body
     end
   end
 

--- a/lib/worker/batcher.ex
+++ b/lib/worker/batcher.ex
@@ -2115,7 +2115,7 @@ defmodule BorsNG.Worker.Batcher do
   end
 
   defp send_message(repo_conn, patches, message) do
-    body = append_bundle_link(Batcher.Message.generate_message(message), message, patches)
+    body = Batcher.Message.generate_message(message, bundle_page_url(patches))
 
     case body do
       nil ->
@@ -2136,19 +2136,12 @@ defmodule BorsNG.Worker.Batcher do
     end
   end
 
-  # A comment about an existing bundle gets a link to its dashboard page. All
-  # members of a bundle share a bundle_id, so the first patch's is
+  # All members of a bundle share a bundle_id, so the first patch's is
   # representative of the group send_message posts to.
-  defp append_bundle_link(nil, _message, _patches), do: nil
+  defp bundle_page_url([%Patch{bundle_id: bundle_id} | _]) when not is_nil(bundle_id),
+    do: bundle_url(Endpoint, :show, bundle_id)
 
-  defp append_bundle_link(body, message, patches) do
-    with true <- Batcher.Message.links_to_bundle?(message),
-         [%Patch{bundle_id: bundle_id} | _] when not is_nil(bundle_id) <- patches do
-      body <> Batcher.Message.bundle_link_footer(bundle_url(Endpoint, :show, bundle_id))
-    else
-      _ -> body
-    end
-  end
+  defp bundle_page_url(_), do: nil
 
   defp send_status(
          repo_conn,

--- a/lib/worker/batcher/message.ex
+++ b/lib/worker/batcher/message.ex
@@ -384,6 +384,51 @@ defmodule BorsNG.Worker.Batcher.Message do
     "Pull request successfully merged into #{target_branch}.\n\n#{status_msg}"
   end
 
+  # Bundle comments carry a trailing link to the bundle's page in the bors
+  # dashboard, so a reader can jump from any member's pull request to the whole
+  # bundle: its members, approval state, and batches. The URL is built by the
+  # caller (which has the router helpers); this module only owns the wording.
+  @bundle_page_messages [
+    :bundle_conflict,
+    :bundle_timeout,
+    :linked,
+    :stacked,
+    :bundle_waiting,
+    :bundle_held,
+    :bundle_last_unapproved,
+    :bundle_pulled,
+    :bundle_failed,
+    :stack_stale,
+    :stack_retarget_failed,
+    :retargeted
+  ]
+
+  @doc """
+  Whether a comment for `message` should link to its bundle's page. True for
+  messages that describe a bundle that still exists. False for link-rejection
+  (`:link_error`), unlink, and base-restore messages, where there is no live
+  bundle to point at.
+  """
+  def links_to_bundle?(message) when is_tuple(message),
+    do: elem(message, 0) in @bundle_page_messages
+
+  def links_to_bundle?(_), do: false
+
+  @doc """
+  The trailing "view this bundle" link appended to bundle comments. `url` is
+  built by the caller. A nil url yields an empty string so callers can append
+  it unconditionally.
+
+  The note about signing in is deliberate: the bundle page sits behind the bors
+  dashboard's login, so any signed-in GitHub user can open it, but a signed-out
+  reader following the link is bounced to a GitHub OAuth prompt rather than the
+  page they expected.
+  """
+  def bundle_link_footer(nil), do: ""
+
+  def bundle_link_footer(url),
+    do: "\n\n[View this bundle in bors](#{url}) (sign in with GitHub to view)."
+
   def gen_status_link(status) do
     case status.url do
       nil -> status.identifier

--- a/lib/worker/batcher/message.ex
+++ b/lib/worker/batcher/message.ex
@@ -393,6 +393,7 @@ defmodule BorsNG.Worker.Batcher.Message do
     :bundle_timeout,
     :linked,
     :stacked,
+    :try_ignores_bundle,
     :bundle_waiting,
     :bundle_held,
     :bundle_last_unapproved,
@@ -412,6 +413,9 @@ defmodule BorsNG.Worker.Batcher.Message do
   def links_to_bundle?(message) when is_tuple(message),
     do: elem(message, 0) in @bundle_page_messages
 
+  def links_to_bundle?(message) when is_atom(message),
+    do: message in @bundle_page_messages
+
   def links_to_bundle?(_), do: false
 
   @doc """
@@ -428,6 +432,24 @@ defmodule BorsNG.Worker.Batcher.Message do
 
   def bundle_link_footer(url),
     do: "\n\n[View this bundle in bors](#{url}) (sign in with GitHub to view)."
+
+  @doc """
+  Like `generate_message/1`, but appends the bundle-page link footer when
+  `message` is one that links to its bundle (see `links_to_bundle?/1`).
+  `bundle_url` is built by the caller (which has the router helpers); pass
+  nil when there is no bundle page to point at.
+  """
+  def generate_message(message, bundle_url) do
+    case generate_message(message) do
+      nil ->
+        nil
+
+      body ->
+        if links_to_bundle?(message),
+          do: body <> bundle_link_footer(bundle_url),
+          else: body
+    end
+  end
 
   def gen_status_link(status) do
     case status.url do

--- a/test/batcher/batcher_bundle_test.exs
+++ b/test/batcher/batcher_bundle_test.exs
@@ -180,7 +180,10 @@ defmodule BorsNG.Worker.BatcherBundleTest do
 
       assert [comment] = comments_for(1)
       assert comment =~ "linked bundle: #1, #2"
-      assert [_comment] = comments_for(2)
+      assert comment =~ "[View this bundle in bors]"
+      assert comment =~ "/bundles/#{patch.bundle_id})"
+      assert [comment2] = comments_for(2)
+      assert comment2 =~ "/bundles/#{patch.bundle_id})"
     end
 
     test "linking an already-bundled patch unions the bundles", %{proj: proj} do

--- a/test/batcher/message_test.exs
+++ b/test/batcher/message_test.exs
@@ -112,6 +112,44 @@ defmodule BorsNG.Worker.BatcherMessageTest do
     end
   end
 
+  test "bundle-status messages link to the bundle page; others do not" do
+    for message <- [
+          {:linked, [1, 2]},
+          {:stacked, 2, 1, "https://github.com/o/r/compare/a...b"},
+          {:bundle_waiting, [7]},
+          {:bundle_held, 7},
+          {:bundle_last_unapproved, :awaiting_review},
+          {:bundle_pulled, 7, :closed},
+          {:bundle_failed, [3, 7], []},
+          {:bundle_conflict, [3, 7]},
+          {:bundle_timeout, [3, 7]},
+          {:stack_stale, 2, 1},
+          {:stack_retarget_failed, 7},
+          {:retargeted, "master"}
+        ] do
+      assert Message.links_to_bundle?(message), "expected #{inspect(message)} to link"
+    end
+
+    for message <- [
+          :unlinked,
+          {:unlinked, :fresh_approval_needed},
+          {:link_error, :closed},
+          {:base_restored, "feature-a"},
+          {:base_restore_failed, "feature-a"},
+          {:preflight, :ok},
+          {:canceled, :failed, :push}
+        ] do
+      refute Message.links_to_bundle?(message), "expected #{inspect(message)} not to link"
+    end
+  end
+
+  test "bundle link footer" do
+    assert Message.bundle_link_footer(nil) == ""
+
+    assert Message.bundle_link_footer("http://localhost/bundles/42") ==
+             "\n\n[View this bundle in bors](http://localhost/bundles/42) (sign in with GitHub to view)."
+  end
+
   test "every bors.toml error key has an explicit, friendly renderer" do
     # Single source of truth: BorsToml's @type err (introspected below), plus
     # the fetch-layer-only :fetch_failed. Adding a new validation key extends

--- a/test/batcher/message_test.exs
+++ b/test/batcher/message_test.exs
@@ -125,7 +125,8 @@ defmodule BorsNG.Worker.BatcherMessageTest do
           {:bundle_timeout, [3, 7]},
           {:stack_stale, 2, 1},
           {:stack_retarget_failed, 7},
-          {:retargeted, "master"}
+          {:retargeted, "master"},
+          :try_ignores_bundle
         ] do
       assert Message.links_to_bundle?(message), "expected #{inspect(message)} to link"
     end
@@ -148,6 +149,24 @@ defmodule BorsNG.Worker.BatcherMessageTest do
 
     assert Message.bundle_link_footer("http://localhost/bundles/42") ==
              "\n\n[View this bundle in bors](http://localhost/bundles/42) (sign in with GitHub to view)."
+  end
+
+  test "generate_message/2 appends the footer only to bundle-page messages" do
+    url = "http://localhost/bundles/42"
+    footer = Message.bundle_link_footer(url)
+
+    assert Message.generate_message({:linked, [1, 2]}, url) ==
+             Message.generate_message({:linked, [1, 2]}) <> footer
+
+    assert Message.generate_message(:try_ignores_bundle, url) ==
+             Message.generate_message(:try_ignores_bundle) <> footer
+
+    # Non-bundle messages pass through unchanged, even with a url.
+    assert Message.generate_message(:unlinked, url) == Message.generate_message(:unlinked)
+
+    # A nil url appends nothing.
+    assert Message.generate_message({:linked, [1, 2]}, nil) ==
+             Message.generate_message({:linked, [1, 2]})
   end
 
   test "every bors.toml error key has an explicit, friendly renderer" do


### PR DESCRIPTION
Comments that bors posts on PRs in a linked or stacked bundle now end with a link to the bundle's dashboard page (/bundles/:id), so a reader can jump from any member's PR to the bundle details.

The link is appended only to comments that describe a bundle that still exists, not to link-rejection, unlink, or base-restore comments where there is no live bundle to point at. It notes that viewing requires signing in with GitHub, since the page sits behind the dashboard login: any signed-in user can view it (not just members or reviewers), but a signed-out reader following the link is bounced to a GitHub OAuth prompt.

The wording lives in Batcher.Message; the URL is built by the callers that already hold the router helpers. Includes tests for the new message helpers and an end-to-end check that a bundle comment carries the /bundles/ link.

🤖 Generated with [Claude Code](https://claude.com/claude-code)