### PR TITLE
feat(bundles): link a stacked member's own changes where comments work

### DIFF
--- a/lib/web/bundle_display.ex
+++ b/lib/web/bundle_display.ex
@@ -123,6 +123,15 @@ defmodule BorsNG.BundleDisplay do
   def member_status(%Patch{}), do: :waiting
 
   @doc """
+  A link showing a stacked member's own changes inside its pull request's
+  files view, where line comments work. Built from the patches' current head
+  commits, so a page rendering it stays fresh as the branches move, unlike
+  the pinned link in the stack announcement comment. Nil when either head
+  commit is unknown (rows that predate head tracking).
+  """
+  defdelegate own_changes_url(project, parent, child), to: Bundles
+
+  @doc """
   A batch's patches in display order: descending PR order, except bundle
   members stay together (sorted by their highest member) with stacks base
   first.

--- a/lib/web/templates/bundle/show.html.eex
+++ b/lib/web/templates/bundle/show.html.eex
@@ -22,12 +22,13 @@
 <p>Date: <%= htmlify_naive_datetime(@bundle.inserted_at) %></p>
 <p>State: <%= render(BorsNG.ProjectView, "_bundle_state.html", state: @state, project: @project) %></p>
 <p>Pull requests<%= if @stacked do %> (stack order)<% end %>:</p>
-<% xrefs = Map.new(@members, fn {patch, _depth} -> {patch.id, patch.pr_xref} end) %>
+<% by_id = Map.new(@members, fn {patch, _depth} -> {patch.id, patch} end) %>
 <ul class=stack-list>
   <%= for {patch, depth} <- @members do %>
+  <% parent = patch.stacked_on_id && by_id[patch.stacked_on_id] %>
   <li style="padding-left: <%= depth * 20 %>px">
     <span class="stack-dot stack-dot--<%= BorsNG.BundleDisplay.member_status(patch) %>" aria-hidden="true">●</span>
-    <a href="<%= Confex.fetch_env!(:bors, :html_github_root) %>/<%= @project.name %>/pull/<%= patch.pr_xref %>"<%= if patch.stacked_on_id && xrefs[patch.stacked_on_id] do %> title="Stacked on #<%= xrefs[patch.stacked_on_id] %>"<% end %>>#<%= patch.pr_xref %></a>
+    <a href="<%= Confex.fetch_env!(:bors, :html_github_root) %>/<%= @project.name %>/pull/<%= patch.pr_xref %>"<%= if parent do %> title="Stacked on #<%= parent.pr_xref %>"<% end %>>#<%= patch.pr_xref %></a>
     —
     <%= cond do %>
     <% not patch.open -> %>
@@ -38,6 +39,11 @@
     <span class=approval--held>✓ held (<%= patch.bundle_reviewer %>)</span>
     <% true -> %>
     <span class=approval--waiting>waiting<%= if logins = Map.get(@delegations, patch.id) do %> — delegated to <%= Enum.join(logins, ", ") %><% end %></span>
+    <% end %>
+    <%= if parent && @project do %>
+    <%= if url = BorsNG.BundleDisplay.own_changes_url(@project, parent, patch) do %>
+    · <a href="<%= url %>">own changes</a>
+    <% end %>
     <% end %>
   </li>
   <% end %>

--- a/lib/worker/batcher.ex
+++ b/lib/worker/batcher.ex
@@ -793,18 +793,10 @@ defmodule BorsNG.Worker.Batcher do
 
           true ->
             members = Bundles.form_stacked(members, patch, target, project.id)
-            compare_url = compare_url(project, target, patch)
-            send_message(repo_conn, members, {:stacked, patch.pr_xref, target_xref, compare_url})
+            url = Bundles.own_changes_url(project, target, patch)
+            send_message(repo_conn, members, {:stacked, patch.pr_xref, target_xref, url})
         end
     end
-  end
-
-  # A point-in-time compare view of the child's own changes: exactly the delta
-  # that contains_head?/3 verified. Built from SHAs, so it works when branches
-  # live in a fork.
-  defp compare_url(project, parent, child) do
-    root = Confex.fetch_env!(:bors, :html_github_root)
-    "#{root}/#{project.name}/compare/#{parent.commit}...#{child.commit}"
   end
 
   def sort_batches(batches) do

--- a/lib/worker/batcher/bundles.ex
+++ b/lib/worker/batcher/bundles.ex
@@ -368,6 +368,26 @@ defmodule BorsNG.Worker.Batcher.Bundles do
   end
 
   @doc """
+  A view of a stacked child's own changes: the delta on top of its parent
+  that `contains_head?/3` verifies, shown inside the child's pull request
+  (`pull/N/files/parent..child`), where reviewers can leave line comments —
+  GitHub compare pages take none. Constructible for every stacked pair bors
+  accepts, forks included: the range only needs the parent's head to be a
+  commit of the child's pull request, which is exactly what
+  `contains_head?/3` checks. The SHAs pin it: a page building it from live
+  rows stays current, a posted comment keeps the view it was built with. The
+  URL outlives the merge — GitHub renders it for closed pull requests.
+  Returns nil when either head commit is unknown.
+  """
+  def own_changes_url(_project, %Patch{commit: nil}, _child), do: nil
+  def own_changes_url(_project, _parent, %Patch{commit: nil}), do: nil
+
+  def own_changes_url(project, parent, child) do
+    root = Confex.fetch_env!(:bors, :html_github_root)
+    "#{root}/#{project.name}/pull/#{child.pr_xref}/files/#{parent.commit}..#{child.commit}"
+  end
+
+  @doc """
   The first stacked member whose branch does not contain the current head of
   the patch it stacks on, returned as `{child, parent}`. Returns nil if every
   stack edge is fresh. An unverifiable comparison counts as stale: this check

--- a/lib/worker/batcher/message.ex
+++ b/lib/worker/batcher/message.ex
@@ -192,8 +192,22 @@ defmodule BorsNG.Worker.Batcher.Message do
     "Note: `bors try` builds this pull request without the rest of its bundle, so its result may differ from the bundle's batch."
   end
 
-  def generate_message({:stacked, child_xref, parent_xref, compare_url}) do
-    "##{child_xref} is now stacked on ##{parent_xref}: both are in a linked bundle and merge in the same batch, or not at all. The batch applies ##{parent_xref}'s changes first ([##{child_xref}'s own changes](#{compare_url})). Each pull request still needs its own `bors r+`; `bors unlink` removes the link."
+  # The review call-out gets its own bold line: buried in a parenthetical,
+  # reviewers overlooked it, and it is the one link they should open — this
+  # pull request's Files tab shows the whole stack below it too. A nil URL
+  # (head commit unknown) just drops the line.
+  def generate_message({:stacked, child_xref, parent_xref, url}) do
+    base =
+      "##{child_xref} is now stacked on ##{parent_xref}: both are in a linked bundle and merge in the same batch, or not at all. The batch applies ##{parent_xref}'s changes first. Each pull request still needs its own `bors r+`; `bors unlink` removes the link."
+
+    case url do
+      nil ->
+        base
+
+      url ->
+        base <>
+          "\n\n**Review:** [##{child_xref}'s own changes](#{url}) — this pull request's diff without ##{parent_xref}'s changes. Line comments there work as usual."
+    end
   end
 
   def generate_message({:bundle_base_edit_mismatch, xref}) do

--- a/test/batcher/batcher_bundle_test.exs
+++ b/test/batcher/batcher_bundle_test.exs
@@ -387,7 +387,8 @@ defmodule BorsNG.Worker.BatcherBundleTest do
       assert p2.stacked_on_id == nil
       assert Enum.any?(comments_for(1), &(&1 =~ "stacked on #2"))
       assert Enum.any?(comments_for(2), &(&1 =~ "stacked on #2"))
-      assert Enum.any?(comments_for(1), &(&1 =~ "/compare/commit-2...commit-1"))
+      # The own-changes link shows the range inside the child's PR files view.
+      assert Enum.any?(comments_for(1), &(&1 =~ "/pull/1/files/commit-2..commit-1"))
     end
 
     test "stack is refused for this pull request's own number", %{proj: proj} do

--- a/test/batcher/bundles_test.exs
+++ b/test/batcher/bundles_test.exs
@@ -88,4 +88,24 @@ defmodule BorsNG.Worker.Batcher.BundlesTest do
       assert {:error, :branch_mismatch} = Bundles.final_target([root, orphan])
     end
   end
+
+  describe "own_changes_url/3" do
+    test "points into the child pull request's files view, parent head to child head" do
+      project = %BorsNG.Database.Project{name: "example/project"}
+      parent = %Patch{commit: "abc", pr_xref: 43}
+      child = %Patch{commit: "def", pr_xref: 44}
+
+      assert Bundles.own_changes_url(project, parent, child) ==
+               "https://github.com/example/project/pull/44/files/abc..def"
+    end
+
+    test "nil when either head commit is unknown" do
+      project = %BorsNG.Database.Project{name: "example/project"}
+      known = %Patch{commit: "abc", pr_xref: 43}
+      unknown = %Patch{commit: nil, pr_xref: 44}
+
+      assert Bundles.own_changes_url(project, unknown, known) == nil
+      assert Bundles.own_changes_url(project, known, unknown) == nil
+    end
+  end
 end

--- a/test/batcher/message_test.exs
+++ b/test/batcher/message_test.exs
@@ -23,9 +23,19 @@ defmodule BorsNG.Worker.BatcherMessageTest do
   test "generate bundle messages" do
     assert Message.generate_message({:linked, [1, 2]}) =~ "linked bundle: #1, #2"
     assert Message.generate_message(:unlinked) =~ "no longer linked"
-    stacked = Message.generate_message({:stacked, 2, 1, "https://github.com/o/r/compare/a...b"})
+
+    stacked =
+      Message.generate_message({:stacked, 2, 1, "https://github.com/o/r/pull/2/files/a..b"})
+
     assert stacked =~ "#2 is now stacked on #1"
-    assert stacked =~ "[#2's own changes](https://github.com/o/r/compare/a...b)"
+    assert stacked =~ "**Review:** [#2's own changes](https://github.com/o/r/pull/2/files/a..b)"
+    assert stacked =~ "Line comments there work as usual"
+
+    # An unknown head commit drops the review line rather than linking nil.
+    unlinkable = Message.generate_message({:stacked, 2, 1, nil})
+    assert unlinkable =~ "#2 is now stacked on #1"
+    refute unlinkable =~ "Review:"
+    refute unlinkable =~ "nil"
     assert Message.generate_message({:link_error, {:not_rebased, 5}}) =~ "Rebase it onto #5"
 
     assert Message.generate_message({:link_error, {:stack_reversed, 5, 2}}) =~

--- a/test/controllers/bundle_controller_test.exs
+++ b/test/controllers/bundle_controller_test.exs
@@ -36,6 +36,7 @@ defmodule BorsNG.BundleControllerTest do
         project_id: project.id,
         pr_xref: 43,
         title: "base patch",
+        commit: "aaaaaaa",
         bundle_id: bundle.id,
         bundle_reviewer: "reviewer"
       })
@@ -45,6 +46,7 @@ defmodule BorsNG.BundleControllerTest do
         project_id: project.id,
         pr_xref: 44,
         title: "stacked patch",
+        commit: "bbbbbbb",
         bundle_id: bundle.id,
         stacked_on_id: base.id
       })
@@ -95,6 +97,34 @@ defmodule BorsNG.BundleControllerTest do
     assert html =~ "None"
     # base before stacked
     assert html =~ ~r/#43.*#44/s
+  end
+
+  test "links a stacked member's own changes inside its pull request", %{
+    conn: conn,
+    bundle: bundle
+  } do
+    conn = login(conn)
+    conn = get(conn, "/bundles/#{bundle.id}")
+
+    html = html_response(conn, 200)
+    assert html =~ "/example/project/pull/44/files/aaaaaaa..bbbbbbb"
+    # only the stacked member gets a link; the root's diff is its own PR
+    assert length(String.split(html, "own changes")) == 2
+  end
+
+  test "omits the own-changes link when a head commit is unknown", %{
+    conn: conn,
+    bundle: bundle,
+    stacked: stacked
+  } do
+    stacked |> Ecto.Changeset.change(commit: nil) |> Repo.update!()
+
+    conn = login(conn)
+    conn = get(conn, "/bundles/#{bundle.id}")
+
+    html = html_response(conn, 200)
+    refute html =~ "own changes"
+    refute html =~ "/files/"
   end
 
   test "lists the batches the bundle entered", %{conn: conn, bundle: bundle, project: project} do


### PR DESCRIPTION
This PR changes where the "own changes" link of a stacked pull request points, and adds it to the bundle detail page.

The stack announcement linked a GitHub compare view, pinned to the SHAs at stack time. Compare pages take no review comments, so reviewers of a stacked child had to comment on the cumulative Files-changed diff. The announcement now links the commit-range view inside the child's pull request (`pull/N/files/parent-head..child-head`). This view shows only the child's own delta, and reviewers can leave line comments there. The range is valid for every stacked pair bors accepts, forks included: it only needs the parent's head to be a commit of the child's PR, which is what `contains_head?/3` verifies. GitHub keeps rendering the view after the PR closes.

The announcement puts the review link on its own bold line ("**Review:** …"), because a link inside a parenthetical was easy to miss. When no URL can be built, the message drops the line instead of linking nil.

The bundle detail page shows the same link on each stacked member's row. The page rebuilds the URL from the current head commits on each render, so it always shows the up-to-date delta, where the posted comment keeps the view it was built with. Every bundle comment already links to this page in its footer. A stack root gets no link, because its pull request diff already shows its own changes. A row gets no link when its head commit is unknown.

The URL builder lives in `Bundles.own_changes_url/3`, shared by the batcher and the web layer.

Tests: unit tests for the URL builder, message tests for the review line and the nil case, an updated batcher assertion for the announcement link, and two controller tests for the page. The full suite passes (625 tests, 8 doctests).
